### PR TITLE
Fix typed actions

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -42,7 +42,7 @@ logger = print
 
 data UpdateTime = UpdateTime
 
-$(deriveJSON defaultOptions ''UpdateTime)
+$(deriveJSON (defaultOptions {tagSingleConstructors = True}) ''UpdateTime)
 
 display :: Maybe UTCTime -> Purview a
 display time = div

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -47,14 +47,14 @@ $(deriveJSON defaultOptions ''UpdateTime)
 display :: Maybe UTCTime -> Purview a
 display time = div
   [ text (show time)
-  , onClick "setTime" $ div [ text "check time" ]
+  , onClick UpdateTime $ div [ text "check time" ]
   ]
 
-startClock cont state = Once (\send -> send "setTime") False (cont state)
+startClock cont state = Once (\send -> send UpdateTime) False (cont state)
 
 timeHandler = EffectHandler Nothing handle
   where
-    handle "setTime" state = Just <$> getCurrentTime
+    handle UpdateTime state = Just <$> getCurrentTime
     handle _ state = pure state
 
 main = run logger (timeHandler (startClock display))

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -131,7 +131,7 @@ applyEvent eventBus message component = case component of
     Success action' ->
       MessageHandler (handler action' state) handler cont
     Error _ ->
-      cont state
+      MessageHandler state handler cont
 
   EffectHandler state handler cont -> case fromJSON message of
     Success parsedAction -> do
@@ -141,10 +141,9 @@ applyEvent eventBus message component = case component of
           { event = "newState"
           , message = toJSON newState
           }
-
       pure $ EffectHandler state handler cont
-    Error _ ->
-      pure $ cont state
+    Error err ->
+      pure $ EffectHandler state handler cont
 
   x -> pure x
 

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -19,6 +19,7 @@ $(deriveJSON defaultOptions ''TestAction)
 spec = parallel $ do
 
   describe "render" $ do
+
     it "can create a div" $ do
       let element = Html "div" [Text "hello world"]
 
@@ -46,7 +47,17 @@ spec = parallel $ do
         `shouldBe`
         "0"
 
+    it "can render a typed action" $ do
+      let element =
+            Attribute (OnClick Up)
+            $ Html "div" [Text "hello world"]
+
+      render [] element `shouldBe`
+        "<div bridge-click=\"Up\">hello world</div>"
+
+
   describe "applyEvent" $ do
+
     it "changes state" $ do
       let
         actionHandler :: String -> Int -> Int
@@ -92,6 +103,7 @@ spec = parallel $ do
         "1"
 
   describe "runOnces" $ do
+
     it "sets hasRun to True" $ do
       let
         display time = div

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -108,6 +108,7 @@ webSocketHandler log component pending = do
   conn <- WS.acceptRequest pending
 
   eventBus <- newTChanIO
+
   atomically $ writeTChan eventBus $ FromEvent { event = "init", message = "init" }
 
   WS.withPingThread conn 30 (pure ()) $ do


### PR DESCRIPTION
Fixes #3 

Pretty silly, when parsing an action failed it was dropping part of the tree (specifically the Message or Effect handler)