### PR TITLE
Actions target specific handlers

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,7 +23,7 @@ $(deriveJSON defaultOptions ''Direction)
 upButton = onClick Up $ div [ text "up" ]
 downButton = onClick Down $ div [ text "down" ]
 
-handler = MessageHandler (0 :: Int) action
+handler = messageHandler (0 :: Int) action
   where
     action Up state   = state + 1
     action Down state = state - 1
@@ -56,9 +56,8 @@ display time = div
 
 startClock cont state = Once (\send -> send UpdateTime) False (cont state)
 
-timeHandler = EffectHandler Nothing handle
+timeHandler = effectHandler Nothing handle
   where
     handle UpdateTime state = Just <$> getCurrentTime
-    handle _ state = pure state
 
 main = run logger (timeHandler (startClock display))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -35,9 +35,16 @@ counter state = div
   , downButton
   ]
 
+component = handler counter
+
+multiCounter = div
+  [ component
+  , component
+  ]
+
 logger = print
 
--- main = run logger (handler counter)
+main = run logger multiCounter
 
 
 -------------------------
@@ -60,4 +67,4 @@ timeHandler = effectHandler Nothing handle
   where
     handle UpdateTime state = Just <$> getCurrentTime
 
-main = run logger (timeHandler (startClock display))
+-- main = run logger (timeHandler (startClock display))

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -86,7 +86,7 @@ onClick = Attribute . OnClick
 renderAttributes :: [Attributes] -> String
 renderAttributes = concatMap renderAttribute
   where
-    renderAttribute (OnClick action) = " bridge-click=" <> unpack (encode action)
+    renderAttribute (OnClick action) = " action=" <> unpack (encode action)
 
 {-|
 
@@ -218,7 +218,7 @@ prepareGraph' location component = case component of
           FromEvent
             { event = "once"
             , message = toJSON message
-            , location = Nothing
+            , location = Just location
             }
     in if not hasRun then
         let

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -98,12 +98,12 @@ render' location attrs tree = case tree of
     render' location (attr:attrs) rest
 
   MessageHandler state _ cont ->
-    "<div handler=" <> show (encode location) <> ">" <>
+    "<div handler=\"" <> concatMap show location <> "\">" <>
       render' (0:location) attrs (cont state) <>
     "</div>"
 
   EffectHandler state _ cont ->
-    "<div handler=" <> show (encode location) <> ">" <>
+    "<div handler=\"" <> concatMap show location <> "\">" <>
       render' (0:location) attrs (cont state) <>
     "</div>"
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -141,6 +141,7 @@ applyNewState eventBus message component = case component of
   EffectHandler loc state handler cont -> case fromJSON message of
     Success newState -> do
       pure $ EffectHandler loc newState handler cont
+
   x -> pure x
 
 applyEvent :: TChan FromEvent -> Value -> Purview a -> IO (Purview a)
@@ -163,6 +164,10 @@ applyEvent eventBus message component = case component of
       pure $ EffectHandler loc state handler cont
     Error err ->
       pure $ EffectHandler loc state handler cont
+
+  Html kind children -> do
+    children' <- mapM (applyEvent eventBus message) children
+    pure $ Html kind children'
 
   x -> pure x
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -98,12 +98,12 @@ render' location attrs tree = case tree of
     render' location (attr:attrs) rest
 
   MessageHandler state _ cont ->
-    "<div handler=\"" <> concatMap show location <> "\">" <>
+    "<div handler=\"" <> show location <> "\">" <>
       render' (0:location) attrs (cont state) <>
     "</div>"
 
   EffectHandler state _ cont ->
-    "<div handler=\"" <> concatMap show location <> "\">" <>
+    "<div handler=\"" <> show location <> "\">" <>
       render' (0:location) attrs (cont state) <>
     "</div>"
 

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -49,7 +49,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"[0]\">0</div>"
+        "<div handler=\"0\">0</div>"
 
     it "can render a typed action" $ do
       let element = onClick SingleConstructor $ div [ text "click" ]
@@ -76,8 +76,8 @@ spec = parallel $ do
       render component
         `shouldBe`
         "<div>" <>
-          "<div handler=\"[0,0]\">0</div>" <>
-          "<div handler=\"[1,0]\">0</div>" <>
+          "<div handler=\"00\">0</div>" <>
+          "<div handler=\"10\">0</div>" <>
         "</div>"
 
     it "renders nested handlers with deeper locations" $ do
@@ -91,8 +91,8 @@ spec = parallel $ do
 
       render component
         `shouldBe`
-        "<div handler=\"[0]\">" <>
-          "<div handler=\"[0,0]\"></div>" <>
+        "<div handler=\"0\">" <>
+          "<div handler=\"00\"></div>" <>
         "</div>"
 
 
@@ -110,7 +110,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"[0]\">0</div>"
+        "<div handler=\"0\">0</div>"
 
       chan <- newTChanIO
 
@@ -118,7 +118,7 @@ spec = parallel $ do
 
       render appliedHandler
         `shouldBe`
-        "<div handler=\"[0]\">1</div>"
+        "<div handler=\"0\">1</div>"
 
     it "works with typed messages" $ do
       let
@@ -132,7 +132,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"[0]\">0</div>"
+        "<div handler=\"0\">0</div>"
 
       chan <- newTChanIO
 
@@ -140,7 +140,7 @@ spec = parallel $ do
 
       render appliedHandler
         `shouldBe`
-        "<div handler=\"[0]\">1</div>"
+        "<div handler=\"0\">1</div>"
 
     it "works after sending an event that did not match anything" $ do
       let
@@ -157,12 +157,12 @@ spec = parallel $ do
       appliedHandler0 <- applyEvent chan (String "init") handler
       render appliedHandler0
         `shouldBe`
-        "<div handler=\"[0]\">0</div>"
+        "<div handler=\"0\">0</div>"
 
       appliedHandler1 <- applyEvent chan (toJSON Up) appliedHandler0
       render appliedHandler1
         `shouldBe`
-        "<div handler=\"[0]\">1</div>"
+        "<div handler=\"0\">1</div>"
 
 
   describe "runOnces" $ do

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -49,7 +49,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"0\">0</div>"
+        "<div handler=\"[0]\">0</div>"
 
     it "can render a typed action" $ do
       let element = onClick SingleConstructor $ div [ text "click" ]
@@ -76,8 +76,8 @@ spec = parallel $ do
       render component
         `shouldBe`
         "<div>" <>
-          "<div handler=\"00\">0</div>" <>
-          "<div handler=\"10\">0</div>" <>
+          "<div handler=\"[0,0]\">0</div>" <>
+          "<div handler=\"[1,0]\">0</div>" <>
         "</div>"
 
     it "renders nested handlers with deeper locations" $ do
@@ -91,8 +91,8 @@ spec = parallel $ do
 
       render component
         `shouldBe`
-        "<div handler=\"0\">" <>
-          "<div handler=\"00\"></div>" <>
+        "<div handler=\"[0]\">" <>
+          "<div handler=\"[0,0]\"></div>" <>
         "</div>"
 
 
@@ -110,7 +110,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"0\">0</div>"
+        "<div handler=\"[0]\">0</div>"
 
       chan <- newTChanIO
 
@@ -118,7 +118,7 @@ spec = parallel $ do
 
       render appliedHandler
         `shouldBe`
-        "<div handler=\"0\">1</div>"
+        "<div handler=\"[0]\">1</div>"
 
     it "works with typed messages" $ do
       let
@@ -132,7 +132,7 @@ spec = parallel $ do
 
       render handler
         `shouldBe`
-        "<div handler=\"0\">0</div>"
+        "<div handler=\"[0]\">0</div>"
 
       chan <- newTChanIO
 
@@ -140,7 +140,7 @@ spec = parallel $ do
 
       render appliedHandler
         `shouldBe`
-        "<div handler=\"0\">1</div>"
+        "<div handler=\"[0]\">1</div>"
 
     it "works after sending an event that did not match anything" $ do
       let
@@ -157,12 +157,12 @@ spec = parallel $ do
       appliedHandler0 <- applyEvent chan (String "init") handler
       render appliedHandler0
         `shouldBe`
-        "<div handler=\"0\">0</div>"
+        "<div handler=\"[0]\">0</div>"
 
       appliedHandler1 <- applyEvent chan (toJSON Up) appliedHandler0
       render appliedHandler1
         `shouldBe`
-        "<div handler=\"0\">1</div>"
+        "<div handler=\"[0]\">1</div>"
 
 
   describe "runOnces" $ do

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -43,7 +43,7 @@ spec = parallel $ do
         actionHandler "up" state = 1
 
         handler =
-          MessageHandler (0 :: Int)
+          MessageHandler Nothing (0 :: Int)
             actionHandler
             (Text . show)
 
@@ -64,7 +64,7 @@ spec = parallel $ do
         actionHandler "up" state = 1
 
         handler =
-          MessageHandler (0 :: Int)
+          MessageHandler Nothing (0 :: Int)
             actionHandler
             (Text . show)
 
@@ -85,7 +85,7 @@ spec = parallel $ do
         actionHandler :: String -> Int -> Int
         actionHandler "up" state = 1
 
-        handler = MessageHandler (0 :: Int) actionHandler
+        handler = MessageHandler Nothing (0 :: Int) actionHandler
 
         component = handler (const $ handler (const $ Text ""))
 
@@ -104,7 +104,7 @@ spec = parallel $ do
         actionHandler "up" state = 1
 
         handler =
-          MessageHandler (0 :: Int)
+          MessageHandler Nothing (0 :: Int)
             actionHandler
             (Text . show)
 
@@ -126,7 +126,7 @@ spec = parallel $ do
         actionHandler Up state = 1
 
         handler =
-          MessageHandler (0 :: Int)
+          MessageHandler Nothing (0 :: Int)
             actionHandler
             (Text . show)
 
@@ -148,7 +148,7 @@ spec = parallel $ do
         actionHandler Up state = 1
 
         handler =
-          MessageHandler (0 :: Int)
+          MessageHandler Nothing (0 :: Int)
             actionHandler
             (Text . show)
 
@@ -165,7 +165,7 @@ spec = parallel $ do
         "<div handler=\"[0]\">1</div>"
 
 
-  describe "runOnces" $ do
+  describe "prepareGraph" $ do
 
     it "sets hasRun to True" $ do
       let
@@ -176,7 +176,7 @@ spec = parallel $ do
 
         startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
 
-        timeHandler = EffectHandler Nothing handle
+        timeHandler = EffectHandler Nothing Nothing handle
           where
             handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime)
             handle "setTime" state = Just <$> getCurrentTime
@@ -184,11 +184,11 @@ spec = parallel $ do
 
         component = timeHandler (startClock display)
 
-      show (fst (runOnces component))
+      show (fst (prepareGraph component))
         `shouldBe`
         "EffectHandler Once True div [  \"Nothing\" Attr div [  \"check time\" ]  ] "
 
-      length (snd (runOnces component))
+      length (snd (prepareGraph component))
         `shouldBe`
         1
 
@@ -201,7 +201,7 @@ spec = parallel $ do
 
         startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
 
-        timeHandler = EffectHandler Nothing handle
+        timeHandler = EffectHandler Nothing Nothing handle
           where
             handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime)
             handle "setTime" state = Just <$> getCurrentTime
@@ -210,9 +210,9 @@ spec = parallel $ do
         component = timeHandler (startClock display)
 
       let
-        run1 = runOnces component
-        run2 = runOnces (fst run1)
-        run3 = runOnces (fst run2)
+        run1 = prepareGraph component
+        run2 = prepareGraph (fst run1)
+        run3 = prepareGraph (fst run2)
 
       length (snd run1) `shouldBe` 1
       length (snd run2) `shouldBe` 0

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -35,7 +35,7 @@ spec = parallel $ do
             $ Html "div" [Text "hello world"]
 
       render element `shouldBe`
-        "<div bridge-click=1>hello world</div>"
+        "<div action=1>hello world</div>"
 
     it "can render a message handler" $ do
       let
@@ -56,7 +56,7 @@ spec = parallel $ do
 
       render element
         `shouldBe`
-        "<div bridge-click=\"SingleConstructor\">click</div>"
+        "<div action=\"SingleConstructor\">click</div>"
 
     it "renders multiple message handlers with different locations" $ do
       let

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -27,14 +27,14 @@ spec = parallel $ do
     it "can create a div" $ do
       let element = Html "div" [Text "hello world"]
 
-      render [] element `shouldBe` "<div>hello world</div>"
+      render element `shouldBe` "<div>hello world</div>"
 
     it "can add an onclick" $ do
       let element =
             Attribute (OnClick (1 :: Integer))
             $ Html "div" [Text "hello world"]
 
-      render [] element `shouldBe`
+      render element `shouldBe`
         "<div bridge-click=1>hello world</div>"
 
     it "can render a message handler" $ do
@@ -47,16 +47,53 @@ spec = parallel $ do
             actionHandler
             (Text . show)
 
-      render [] handler
+      render handler
         `shouldBe`
-        "0"
+        "<div handler=\"[0]\">0</div>"
 
     it "can render a typed action" $ do
       let element = onClick SingleConstructor $ div [ text "click" ]
 
-      render [] element
+      render element
         `shouldBe`
         "<div bridge-click=\"SingleConstructor\">click</div>"
+
+    it "renders multiple message handlers with different locations" $ do
+      let
+        actionHandler :: String -> Int -> Int
+        actionHandler "up" state = 1
+
+        handler =
+          MessageHandler (0 :: Int)
+            actionHandler
+            (Text . show)
+
+        component = div
+          [ handler
+          , handler
+          ]
+
+      render component
+        `shouldBe`
+        "<div>" <>
+          "<div handler=\"[0,0]\">0</div>" <>
+          "<div handler=\"[1,0]\">0</div>" <>
+        "</div>"
+
+    it "renders nested handlers with deeper locations" $ do
+      let
+        actionHandler :: String -> Int -> Int
+        actionHandler "up" state = 1
+
+        handler = MessageHandler (0 :: Int) actionHandler
+
+        component = handler (const $ handler (const $ Text ""))
+
+      render component
+        `shouldBe`
+        "<div handler=\"[0]\">" <>
+          "<div handler=\"[0,0]\"></div>" <>
+        "</div>"
 
 
   describe "applyEvent" $ do
@@ -71,17 +108,17 @@ spec = parallel $ do
             actionHandler
             (Text . show)
 
-      render [] handler
+      render handler
         `shouldBe`
-        "0"
+        "<div handler=\"[0]\">0</div>"
 
       chan <- newTChanIO
 
       appliedHandler <- applyEvent chan (String "up") handler
 
-      render [] appliedHandler
+      render appliedHandler
         `shouldBe`
-        "1"
+        "<div handler=\"[0]\">1</div>"
 
     it "works with typed messages" $ do
       let
@@ -93,17 +130,17 @@ spec = parallel $ do
             actionHandler
             (Text . show)
 
-      render [] handler
+      render handler
         `shouldBe`
-        "0"
+        "<div handler=\"[0]\">0</div>"
 
       chan <- newTChanIO
 
       appliedHandler <- applyEvent chan (toJSON Up) handler
 
-      render [] appliedHandler
+      render appliedHandler
         `shouldBe`
-        "1"
+        "<div handler=\"[0]\">1</div>"
 
     it "works after sending an event that did not match anything" $ do
       let
@@ -118,14 +155,14 @@ spec = parallel $ do
       chan <- newTChanIO
 
       appliedHandler0 <- applyEvent chan (String "init") handler
-      render [] appliedHandler0
+      render appliedHandler0
         `shouldBe`
-        "0"
+        "<div handler=\"[0]\">0</div>"
 
       appliedHandler1 <- applyEvent chan (toJSON Up) appliedHandler0
-      render [] appliedHandler1
+      render appliedHandler1
         `shouldBe`
-        "1"
+        "<div handler=\"[0]\">1</div>"
 
 
   describe "runOnces" $ do

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -17,7 +17,7 @@ data FromEvent = FromEvent
   { event :: Text
   , message :: Value
   , location :: Maybe [Int]
-  } deriving (Show, Eq)
+  } deriving (Show, Eq, Generic)
 
 instance FromJSON FromEvent where
   parseJSON (Object o) =

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -16,11 +16,12 @@ data Event = Event
 data FromEvent = FromEvent
   { event :: Text
   , message :: Value
+  , location :: Maybe [Int]
   } deriving (Show, Eq)
 
 instance FromJSON FromEvent where
   parseJSON (Object o) =
-      FromEvent <$> o .: "event" <*> (o .: "message")
+      FromEvent <$> o .: "event" <*> (o .: "message") <*> o .: "location"
   parseJSON _ = error "fail"
 
 instance ToJSON Event where

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -58,7 +58,7 @@ requestHandler routes =
       $ LazyText.fromStrict
       $ wrapHtml
       $ Data.Text.pack
-      $ render [] routes
+      $ render routes
 
 
 --
@@ -71,7 +71,7 @@ requestHandler routes =
 looper :: Log IO -> TChan FromEvent -> WS.Connection -> Purview a -> IO ()
 looper log eventBus connection component = do
   message <- atomically $ readTChan eventBus
-  log $ "\x1b[34;1mreceived>\x1b[0m " <> show message
+  log $ "received> " <> show message
 
   let
     (FromEvent eventKind eventMessage) = message
@@ -82,9 +82,9 @@ looper log eventBus connection component = do
   mapM_ (atomically . writeTChan eventBus) actions
 
   let
-    newHtml = render [] newTree'
+    newHtml = render newTree'
 
-  log $ "\x1b[32;1msending>\x1b[0m " <> show newHtml
+  log $ "sending> " <> show newHtml
 
   WS.sendTextData
     connection

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -6,6 +6,8 @@ module Purview
   , text
   , onClick
   , Purview (..)
+  , messageHandler
+  , effectHandler
   , run
   -- for testing
   , render
@@ -74,8 +76,8 @@ looper log eventBus connection component = do
   log $ "received> " <> show message
 
   let
-    (FromEvent eventKind eventMessage) = message
-    (newTree, actions) = runOnces component
+    FromEvent { event=eventKind, message=eventMessage } = message
+    (newTree, actions) = prepareGraph component
 
   newTree' <- apply eventBus message newTree
 
@@ -109,7 +111,7 @@ webSocketHandler log component pending = do
 
   eventBus <- newTChanIO
 
-  atomically $ writeTChan eventBus $ FromEvent { event = "init", message = "init" }
+  atomically $ writeTChan eventBus $ FromEvent { event = "init", message = "init", location = Nothing }
 
   WS.withPingThread conn 30 (pure ()) $ do
     forkIO $ webSocketMessageHandler eventBus conn

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -8,7 +8,7 @@ import Purview
 upButton = onClick ("up" :: String) $ div [ text "up" ]
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
-handler = MessageHandler 0 action
+handler = MessageHandler Nothing 0 action
   where
     action :: String -> Int -> Int
     action "up"    _ = 1

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -47,7 +47,6 @@ websocketScript = [r|
   function handleEvents(handler, event) {
     var clickValue = event.target.getAttribute("action");
     var location = JSON.parse(handler.getAttribute("handler"))
-    console.log(location)
     if (clickValue) {
       window.ws.send(JSON.stringify({ "event": "click", "message": clickValue, "location": location }));
     }

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -25,6 +25,7 @@ websocketScript = [r|
       if (event.event === "setHtml") {
         // cool enough for now
         document.body.innerHTML = event.message;
+        bindEvents();
       }
     };
 
@@ -43,15 +44,20 @@ websocketScript = [r|
   }
   connect();
 
-  function handleEvents(event) {
+  function handleEvents(handler, event) {
     var clickValue = event.target.getAttribute("action");
+    var location = JSON.parse(handler.getAttribute("handler"))
+    console.log(location)
     if (clickValue) {
-      window.ws.send(JSON.stringify({ "event": "click", "message": clickValue }));
+      window.ws.send(JSON.stringify({ "event": "click", "message": clickValue, "location": location }));
     }
   }
 
   function bindEvents() {
-    document.getRootNode().addEventListener("click", handleEvents);
+    document.querySelectorAll("[handler]").forEach(item => {
+      item.addEventListener("click", event => handleEvents(item, event));
+    });
+    console.log('events bound');
   }
   bindEvents();
 |]

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -44,7 +44,7 @@ websocketScript = [r|
   connect();
 
   function handleEvents(event) {
-    var clickValue = event.target.getAttribute("bridge-click");
+    var clickValue = event.target.getAttribute("action");
     if (clickValue) {
       window.ws.send(JSON.stringify({ "event": "click", "message": clickValue }));
     }


### PR DESCRIPTION
There is more to tidy up with this, but this fixes #2.  Now events should only go to the handler if their location matches.

To look into: nested handlers, as I believe events are still bubbling.