### PR TITLE
Allow different handlers to be side-by-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ module Main where
 import Prelude hiding (div)
 import Data.Aeson
 import Data.Aeson.TH
+
 import Purview
 
 data Direction = Up | Down
@@ -44,9 +45,7 @@ main = run logger (handler counter)
 * Actually diff the html 
 * Development environment (hot reloading, printing messages to/from the server)
 * Allowing CSS + JS snippets in components
-* Tests
 * Performance
-* Type the messages or die trying
 * Collect ideas
 * Hey how do I do side effects?
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,6 +20,10 @@ data Direction = Up | Down
 
 $(deriveJSON defaultOptions ''Direction)
 
+data OtherDirection = Port | Starboard
+
+$(deriveJSON defaultOptions ''OtherDirection)
+
 upButton = onClick Up $ div [ text "up" ]
 downButton = onClick Down $ div [ text "down" ]
 
@@ -28,7 +32,14 @@ handler = messageHandler (0 :: Int) action
     action Up state   = state + 1
     action Down state = state - 1
 
-counter :: Int -> Purview a
+handler' = messageHandler (0 :: Int) action
+  where
+    action Port state   = state + 1
+    action Starboard state = state - 1
+
+component' = handler' (\state -> div [ text "" ])
+
+counter :: Int -> Purview Direction
 counter state = div
   [ upButton
   , text $ "count: " <> show state
@@ -39,7 +50,7 @@ component = handler counter
 
 multiCounter = div
   [ component
-  , component
+  , component'
   ]
 
 logger = print
@@ -51,20 +62,20 @@ main = run logger multiCounter
 -- Server Time Example --
 -------------------------
 
-data UpdateTime = UpdateTime
-
-$(deriveJSON (defaultOptions {tagSingleConstructors = True}) ''UpdateTime)
-
-display :: Maybe UTCTime -> Purview a
-display time = div
-  [ text (show time)
-  , onClick UpdateTime $ div [ text "check time" ]
-  ]
-
-startClock cont state = Once (\send -> send UpdateTime) False (cont state)
-
-timeHandler = effectHandler Nothing handle
-  where
-    handle UpdateTime state = Just <$> getCurrentTime
+-- data UpdateTime = UpdateTime
+--
+-- $(deriveJSON (defaultOptions {tagSingleConstructors = True}) ''UpdateTime)
+--
+-- display :: Maybe UTCTime -> Purview a
+-- display time = div
+--   [ text (show time)
+--   , onClick UpdateTime $ div [ text "check time" ]
+--   ]
+--
+-- startClock cont state = Once (\send -> send UpdateTime) False (cont state)
+--
+-- timeHandler = effectHandler Nothing handle
+--   where
+--     handle UpdateTime state = Just <$> getCurrentTime
 
 -- main = run logger (timeHandler (startClock display))


### PR DESCRIPTION
Fixes #10 

This allows strict typing for actions.  It also does away with `MessageHandler`, in that it's not needed anymore (since it can be done in terms of EffectHandler).  I'm not sure I love the trade off though, since EffectHandler is heavier, so it's still in the code.