### PR TITLE
Diffing basics

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,12 +29,12 @@ downButton = onClick Down $ div [ text "down" ]
 
 handler = messageHandler (0 :: Int) action
   where
-    action Up state   = state + 1
+    action Up   state = state + 1
     action Down state = state - 1
 
 handler' = messageHandler (0 :: Int) action
   where
-    action Port state   = state + 1
+    action Port      state = state + 1
     action Starboard state = state - 1
 
 component' = handler' (\state -> div [ text "" ])
@@ -50,7 +50,7 @@ component = handler counter
 
 multiCounter = div
   [ component
-  , component'
+  -- , component'
   ]
 
 logger = print

--- a/package.yaml
+++ b/package.yaml
@@ -42,8 +42,8 @@ library:
   source-dirs: src
   exposed-modules:
     - Purview
-  ghc-options:
-    - -Wall
+#  ghc-options:
+#    - -Wall
 
 executables:
   purview-exe:

--- a/purview.cabal
+++ b/purview.cabal
@@ -29,6 +29,8 @@ library
   other-modules:
       Component
       ComponentSpec
+      Diffing
+      DiffingSpec
       Events
       PurviewSpec
       Spec
@@ -36,7 +38,6 @@ library
       Paths_purview
   hs-source-dirs:
       src
-  ghc-options: -Wall
   build-tool-depends:
       hspec-discover:hspec-discover ==2.*
   build-depends:
@@ -90,6 +91,8 @@ test-suite purview-test
   other-modules:
       Component
       ComponentSpec
+      Diffing
+      DiffingSpec
       Events
       Purview
       PurviewSpec

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -9,6 +9,7 @@ module Component where
 import           Data.ByteString.Lazy.Char8 (unpack)
 import           Data.Aeson
 import           Data.List (find)
+import           Data.Typeable
 import           Unsafe.Coerce
 import           Control.Concurrent.STM.TChan
 import           Control.Monad.STM
@@ -32,7 +33,7 @@ data Purview a where
   Value :: Show a => a -> Purview a
 
   MessageHandler
-    :: (FromJSON action, FromJSON state)
+    :: (FromJSON action, FromJSON state, Typeable state, Eq state)
     => Identifier
     -> state
     -> (action -> state -> state)
@@ -84,11 +85,11 @@ onClick :: ToJSON b => b -> Purview b -> Purview b
 onClick = Attribute . OnClick
 
 messageHandler
-  :: (FromJSON b, FromJSON t, ToJSON t)
-  => t
-  -> (b -> t -> t)
-  -> (t -> Purview b)
-  -> Purview a
+  :: (FromJSON action, FromJSON state, ToJSON state, Typeable state, Eq state)
+  => state
+  -> (action -> state -> state)
+  -> (state -> Purview action)
+  -> Purview action
 messageHandler state handler =
   Hide . MessageHandler Nothing state handler
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -41,7 +41,7 @@ data Purview a where
     -> Purview a
 
   EffectHandler
-    :: (FromJSON action, FromJSON state, ToJSON state)
+    :: (FromJSON action, FromJSON state, ToJSON state, Typeable state, Eq state)
     => Identifier
     -> state
     -> (action -> state -> IO state)
@@ -94,11 +94,11 @@ messageHandler state handler =
   Hide . MessageHandler Nothing state handler
 
 effectHandler
-  :: (FromJSON b, FromJSON state, ToJSON state)
+  :: (FromJSON action, FromJSON state, ToJSON state, Typeable state, Eq state)
   => state
-  -> (b -> state -> IO state)
-  -> (state -> Purview b)
-  -> Purview a
+  -> (action -> state -> IO state)
+  -> (state -> Purview action)
+  -> Purview action
 effectHandler state handler =
   Hide . EffectHandler Nothing state handler
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -37,8 +37,8 @@ data Purview a where
     => Identifier
     -> state
     -> (action -> state -> state)
-    -> (state -> Purview a)
-    -> Purview a
+    -> (state -> Purview action)
+    -> Purview action
 
   EffectHandler
     :: (FromJSON action, FromJSON state, ToJSON state, Typeable state, Eq state)
@@ -89,7 +89,7 @@ messageHandler
   => state
   -> (action -> state -> state)
   -> (state -> Purview action)
-  -> Purview action
+  -> Purview a
 messageHandler state handler =
   Hide . MessageHandler Nothing state handler
 
@@ -98,7 +98,7 @@ effectHandler
   => state
   -> (action -> state -> IO state)
   -> (state -> Purview action)
-  -> Purview action
+  -> Purview a
 effectHandler state handler =
   Hide . EffectHandler Nothing state handler
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -239,6 +239,8 @@ This walks through the tree and collects actions that should be run
 only once, and sets their run value to True.  It's up to something
 else to actually send the actions.
 
+It also assigns a location to message and effect handlers.
+
 -}
 
 prepareGraph :: Purview a -> (Purview a, [FromEvent])

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -1,0 +1,52 @@
+module Diffing where
+
+import Data.Typeable
+import Component
+
+{-
+
+Since actions target specific locations, we can't stop going the tree early
+because changes may have happened beneath the top level.  kind of the
+downside not having a single, passed down, state.
+
+We still need render, but render needs to be targeted to specific locations.
+
+I dunno how it should work lol.
+
+Let's start at the basics, with dumb tests.  If there's a div in the new
+tree, and not one in the old tree, it should produce something saying
+to add that div.
+
+To know where to make a change, I guess you need a location and a command.
+
+-}
+
+data Change a = Update Location a | Delete Location a | Add Location a
+  deriving (Show, Eq)
+
+diff :: Location -> Purview a -> Purview a -> [Change (Purview a)]
+diff location oldGraph newGraph = case (oldGraph, newGraph) of
+
+  (Html kind children, Html kind' children') ->
+    concatMap
+      (\(index, oldChild, newChild) -> diff (index:location) oldChild newChild)
+      (zip3 [0..] children children')
+
+  (Text str, Text str') ->
+    [Update location (Text str') | str /= str']
+
+  (Html kind children, unknown) ->
+    [Update location unknown]
+
+  (unknown, Html kind children) ->
+    [Update location newGraph]
+
+  (Hide (MessageHandler _ state _ cont), Hide (MessageHandler _ newState _ newCont)) ->
+    case cast state of
+      Just state' ->
+        [Update location newGraph | state' /= newState]
+      -- different kinds of state
+      Nothing ->
+        [Update location newGraph]
+
+  (a, b) -> error (show a <> "\n" <> show b)

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Diffing where
 
+import GHC.Generics
 import Data.Typeable
+import Data.Aeson
+
 import Component
 
 {-
@@ -22,7 +26,10 @@ To know where to make a change, I guess you need a location and a command.
 -}
 
 data Change a = Update Location a | Delete Location a | Add Location a
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance ToJSON a => ToJSON (Change a) where
+  toEncoding = genericToEncoding defaultOptions
 
 diff :: Location -> Purview a -> Purview a -> [Change (Purview a)]
 diff location oldGraph newGraph = case (oldGraph, newGraph) of
@@ -36,7 +43,7 @@ diff location oldGraph newGraph = case (oldGraph, newGraph) of
     [Update location (Text str') | str /= str']
 
   (Html kind children, unknown) ->
-    [Update location unknown]
+    [Update location newGraph]
 
   (unknown, Html kind children) ->
     [Update location newGraph]

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -49,4 +49,12 @@ diff location oldGraph newGraph = case (oldGraph, newGraph) of
       Nothing ->
         [Update location newGraph]
 
+  (Hide (EffectHandler _ state _ cont), Hide (EffectHandler _ newState _ newCont)) ->
+    case cast state of
+      Just state' ->
+        [Update location newGraph | state' /= newState]
+      -- different kinds of state
+      Nothing ->
+        [Update location newGraph]
+
   (a, b) -> error (show a <> "\n" <> show b)

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -33,22 +33,41 @@ spec = parallel $ do
 
       diff [] oldTree newTree `shouldBe` [Update [0] (div [ text "morning" ])]
 
-    it "doesn't diff handler children if the state is the same" $ do
-      let
-        mkHandler = messageHandler "initial state" (\action state -> state <> action)
-        oldTree = div [ mkHandler (const (text "the original")) ]
-        newTree = div [ mkHandler (const (text "this is different")) ]
+    describe "message handlers" $ do
+      it "doesn't diff handler children if the state is the same" $ do
+        let
+          mkHandler = messageHandler "initial state" (\action state -> state <> action)
+          oldTree = div [ mkHandler (const (text "the original")) ]
+          newTree = div [ mkHandler (const (text "this is different")) ]
 
-      diff [] oldTree newTree `shouldBe` []
+        diff [] oldTree newTree `shouldBe` []
 
-    it "diffs handler children if the state is different" $ do
-      let
-        handler1 = messageHandler "initial state" (\action state -> state <> action)
-        handler2 = messageHandler "different state" (\action state -> state <> action)
-        oldTree = div [ handler1 (const (text "the original")) ]
-        newTree = div [ handler2 (const (text "this is different")) ]
+      it "diffs handler children if the state is different" $ do
+        let
+          handler1 = messageHandler "initial state" (\action state -> state <> action)
+          handler2 = messageHandler "different state" (\action state -> state <> action)
+          oldTree = div [ handler1 (const (text "the original")) ]
+          newTree = div [ handler2 (const (text "this is different")) ]
 
-      diff [] oldTree newTree `shouldBe` [Update [0] (handler2 (const (text "this is different")))]
+        diff [] oldTree newTree `shouldBe` [Update [0] (handler2 (const (text "this is different")))]
+
+    describe "effect handlers" $ do
+      it "doesn't diff handler children if the state is the same" $ do
+        let
+          mkHandler = effectHandler "initial state" (\action state -> pure $ state <> action)
+          oldTree = div [ mkHandler (const (text "the original")) ]
+          newTree = div [ mkHandler (const (text "this is different")) ]
+
+        diff [] oldTree newTree `shouldBe` []
+
+      it "diffs handler children if the state is different" $ do
+        let
+          handler1 = effectHandler "initial state" (\action state -> pure $ state <> action)
+          handler2 = effectHandler "different state" (\action state -> pure $ state <> action)
+          oldTree = div [ handler1 (const (text "the original")) ]
+          newTree = div [ handler2 (const (text "this is different")) ]
+
+        diff [] oldTree newTree `shouldBe` [Update [0] (handler2 (const (text "this is different")))]
 
 
 main :: IO ()

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -1,0 +1,55 @@
+module DiffingSpec where
+
+import Prelude hiding (div)
+import Test.Hspec
+
+import Diffing
+import Purview
+
+
+spec :: SpecWith ()
+spec = parallel $ do
+
+  describe "diff" $ do
+
+    it "creates an update for differing text" $ do
+      let
+        oldTree = div [ text "night" ]
+        newTree = div [ text "morning" ]
+
+      diff [] oldTree newTree `shouldBe` [Update [0] (text "morning")]
+
+    it "can do a nested update" $ do
+      let
+        oldTree = div [ div [ text "night" ] ]
+        newTree = div [ div [ text "morning" ] ]
+
+      diff [] oldTree newTree `shouldBe` [Update [0, 0] (text "morning")]
+
+    it "says to update the whole underlying tree on added div" $ do
+      let
+        oldTree = div [ text "night" ]
+        newTree = div [ div [ text "morning" ] ]
+
+      diff [] oldTree newTree `shouldBe` [Update [0] (div [ text "morning" ])]
+
+    it "doesn't diff handler children if the state is the same" $ do
+      let
+        mkHandler = messageHandler "initial state" (\action state -> state <> action)
+        oldTree = div [ mkHandler (const (text "the original")) ]
+        newTree = div [ mkHandler (const (text "this is different")) ]
+
+      diff [] oldTree newTree `shouldBe` []
+
+    it "diffs handler children if the state is different" $ do
+      let
+        handler1 = messageHandler "initial state" (\action state -> state <> action)
+        handler2 = messageHandler "different state" (\action state -> state <> action)
+        oldTree = div [ handler1 (const (text "the original")) ]
+        newTree = div [ handler2 (const (text "this is different")) ]
+
+      diff [] oldTree newTree `shouldBe` [Update [0] (handler2 (const (text "this is different")))]
+
+
+main :: IO ()
+main = hspec spec

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -8,9 +8,9 @@ import           Data.Text (Text)
 import           Data.Aeson
 import           GHC.Generics
 
-data Event = Event
+data Event m = Event
   { event :: Text
-  , message :: Text
+  , message :: m
   } deriving (Generic, Show)
 
 data FromEvent = FromEvent
@@ -24,5 +24,5 @@ instance FromJSON FromEvent where
       FromEvent <$> o .: "event" <*> (o .: "message") <*> o .: "location"
   parseJSON _ = error "fail"
 
-instance ToJSON Event where
+instance ToJSON m => ToJSON (Event m) where
   toEncoding = genericToEncoding defaultOptions

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -11,8 +11,8 @@ upButton = onClick ("up" :: String) $ div [ text "up" ]
 downButton :: Purview String
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
-handler :: (Int -> Purview a) -> Purview a
-handler = MessageHandler Nothing 0 action
+handler :: (Int -> Purview String) -> Purview a
+handler = messageHandler 0 action
   where
     action :: String -> Int -> Int
     action "up" _ = 1

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -24,7 +24,7 @@ websocketScript = [r|
       var event = JSON.parse(evt.data);
       if (event.event === "setHtml") {
         // cool enough for now
-        document.body.innerHTML = event.message;
+        event.message.map(command => setHtml(command));
         bindEvents();
       }
     };
@@ -43,6 +43,22 @@ websocketScript = [r|
     window.ws = ws;
   }
   connect();
+
+  function getNode(location) {
+    let currentNode = document.body;
+    while (location.length > 0) {
+      const index = location.pop();
+      currentNode = currentNode.childNodes[index];
+    }
+    return currentNode;
+  }
+
+  function setHtml(message) {
+    const command = message.message;
+    const [location, newHtml] = message.contents;
+    const targetNode = getNode(location.reverse());
+    targetNode.innerHTML = newHtml;
+  }
 
   function handleEvents(handler, event) {
     event.stopPropagation();


### PR DESCRIPTION
Instead of sending the entire tree each time, a list of commands is sent to the front end.  For now the only implement command is `Update`.  This definitely could be improved (and much more clever) but for now it's focused on re-rendering at the effect or message handler level, if there was no state change from an event it skips rendering for everything beneath that handler.

What the front end used to receive:
```
{ message: "setHtml", contents: <the entire body for html> }
```
Now:
```
{ message: "setHtml", contents: [Update <location> <new html>] }
```
