### PR TITLE
Fix overwriting other handlers

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -50,7 +50,8 @@ component = handler counter
 
 multiCounter = div
   [ component
-  -- , component'
+  , component
+  , component
   ]
 
 logger = print

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -87,7 +87,7 @@ looper log eventBus connection component = do
 
   let
     -- so I think here, we diff then render the diffs
-    diffs = diff [] component newTree'
+    diffs = diff [0] component newTree'
     renderedDiffs = fmap (\(Update location graph) -> Update location (render graph)) diffs
 
   -- log $ "new html> " <> show newTree'

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -56,15 +56,15 @@ websocketScript = [r|
   function setHtml(message) {
     const command = message.message;
     const [location, newHtml] = message.contents;
-    const targetNode = getNode(location.reverse());
+    const targetNode = getNode(location);
     targetNode.innerHTML = newHtml;
   }
 
-  function handleEvents(handler, event) {
+  function handleEvents(event) {
     event.stopPropagation();
 
     var clickValue = event.target.getAttribute("action");
-    var location = JSON.parse(handler.getAttribute("handler"))
+    var location = JSON.parse(event.currentTarget.getAttribute("handler"))
 
     if (clickValue) {
       window.ws.send(JSON.stringify({ "event": "click", "message": clickValue, "location": location }));
@@ -73,7 +73,8 @@ websocketScript = [r|
 
   function bindEvents() {
     document.querySelectorAll("[handler]").forEach(item => {
-      item.addEventListener("click", event => handleEvents(item, event));
+      item.removeEventListener("click", handleEvents);
+      item.addEventListener("click", handleEvents);
     });
     console.log('events bound');
   }


### PR DESCRIPTION
Fixes overwriting handlers and adding too many event listeners.

This will probably need to be revisited since the interaction between a handler with a location of `[0]` I'm not so sure of.  Might just blow up?