### PR TITLE
Handle multiple attributes

### DIFF
--- a/src/Component.hs
+++ b/src/Component.hs
@@ -132,6 +132,11 @@ isSubmit :: Attributes a -> Bool
 isSubmit (OnSubmit _) = True
 isSubmit _            = False
 
+renderGeneric :: Attributes a -> String
+renderGeneric attr = case attr of
+  (Generic name value) -> " " <> name <> "=" <> unpack (encode value)
+  _ -> ""
+
 renderAttributes :: [Attributes a] -> String
 renderAttributes attrs =
   let styles = concatMap getStyle attrs
@@ -142,18 +147,15 @@ renderAttributes attrs =
         Just (OnClick action) -> " action=" <> unpack (encode action)
         _                     -> ""
 
-      -- find one single generic
-      generic = find isGeneric attrs
-      renderGeneric = case generic of
-        Just (Generic name value) -> " " <> name <> "=" <> unpack (encode value)
-        _ -> ""
+      generics = filter isGeneric attrs
+      renderedGenerics = concatMap renderGeneric generics
 
       submit = find isSubmit attrs
       renderSubmit = case submit of
         Just (OnSubmit action) -> " action=" <> unpack (encode action)
         _                      -> ""
   in
-    renderStyle <> renderClick <> renderSubmit <> renderGeneric
+    renderStyle <> renderClick <> renderSubmit <> renderedGenerics
 
 {-|
 

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -56,8 +56,8 @@ spec = parallel $ do
 
     it "can render classes and ids at the same time" $ do
       let element =
-            identifier "hello"
-            $ classes ["class1", "class2", "class3"]
+            classes ["class1", "class2", "class3"]
+            $ identifier "hello"
             $ div [text "it's a hello div"]
       render element `shouldBe` "<div id=\"hello\" class=\"class1 class2 class3\">it's a hello div</div>"
 

--- a/src/ComponentSpec.hs
+++ b/src/ComponentSpec.hs
@@ -54,6 +54,13 @@ spec = parallel $ do
             classes ["class1", "class2", "class3"] $ div [text "it's a hello div"]
       render element `shouldBe` "<div class=\"class1 class2 class3\">it's a hello div</div>"
 
+    it "can render classes and ids at the same time" $ do
+      let element =
+            identifier "hello"
+            $ classes ["class1", "class2", "class3"]
+            $ div [text "it's a hello div"]
+      render element `shouldBe` "<div id=\"hello\" class=\"class1 class2 class3\">it's a hello div</div>"
+
     it "can render a form" $ do
       let
         named = Attribute . Generic "name"


### PR DESCRIPTION
Qs:

1) For the renderGeneric function, is it possible to constrain it to only allow passing in `Generic` or do I have to allow all attribute types?

2) Would we want to make this more "type safe" so id / classes / etc are all their own types so we can avoid something like
```haskell
let element =
            identifier "hello"
            $ identifier "world"
            $ div [text "it's a hello div"]
```