### PR TITLE
Remove MessageHandler from AST

### DIFF
--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -48,14 +48,6 @@ diff location oldGraph newGraph = case (oldGraph, newGraph) of
   (unknown, Html kind children) ->
     [Update location newGraph]
 
-  (Hide (MessageHandler _ state _ cont), Hide (MessageHandler _ newState _ newCont)) ->
-    case cast state of
-      Just state' ->
-        [Update location newGraph | state' /= newState]
-      -- different kinds of state
-      Nothing ->
-        [Update location newGraph]
-
   (Hide (EffectHandler _ state _ cont), Hide (EffectHandler _ newState _ newCont)) ->
     case cast state of
       Just state' ->

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -6,6 +6,8 @@ import Test.Hspec
 import Diffing
 import Purview
 
+type DefaultAction = DirectedEvent String String
+
 spec :: SpecWith ()
 spec = parallel $ do
 
@@ -35,7 +37,7 @@ spec = parallel $ do
     describe "message handlers" $ do
       it "doesn't diff handler children if the state is the same" $ do
         let
-          mkHandler = messageHandler "initial state" (\action state -> state <> action)
+          mkHandler = messageHandler "initial state" (\action state -> (state <> action, [] :: [DefaultAction]))
           oldTree = div [ mkHandler (const (text "the original")) ]
           newTree = div [ mkHandler (const (text "this is different")) ]
 
@@ -43,8 +45,8 @@ spec = parallel $ do
 
       it "diffs handler children if the state is different" $ do
         let
-          handler1 = messageHandler "initial state" (\action state -> state <> action)
-          handler2 = messageHandler "different state" (\action state -> state <> action)
+          handler1 = messageHandler "initial state" (\action state -> (state <> action, [] :: [DefaultAction]))
+          handler2 = messageHandler "different state" (\action state -> (state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -14,9 +14,9 @@ downButton = onClick ("down" :: String) $ div [ text "down" ]
 handler :: (Int -> Purview String) -> Purview a
 handler = messageHandler 0 action
   where
-    action :: String -> Int -> Int
-    action "up" _ = 1
-    action _    _ = 0
+    action :: String -> Int -> (Int, [DirectedEvent String String])
+    action "up" _ = (1, [])
+    action _    _ = (0, [])
 
 counter :: Show a => a -> Purview String
 counter state = div


### PR DESCRIPTION
Fix #32

For now at least it's better to have a single path for events and applying events, easier to think about and to maintain.  The fast-path pure message handler could be reintroduced at some point if people want it, or if event handler turns out to be slow.