### PR TITLE
Todo example with a little styling

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,9 +48,9 @@ handler = effectHandler [] action
       (todos <> [Todo { description=description, done=False }], [])
 
     action (Toggle n) todos =
-      let change (index, todo) =
+      let change (index, todo@Todo { done=alreadyDone }) =
             if index == n
-            then todo { done=True }
+            then todo { done=not alreadyDone }
             else todo
       in pure (fmap change (zip [0..] todos), [])
 
@@ -60,7 +60,7 @@ todoItem (index, Todo { description, done }) = div
   [ text description
   , onClick (Toggle index)
       $ typeAttr "checkbox"
-      $ (if done then checkedAttr "checked" else checkedAttr "")
+      $ (if done then checkedAttr "checked" else id)
       $ input []
   ]
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,7 +30,6 @@ typeAttr = Attribute . Generic "type"
 checkedAttr = Attribute . Generic "checked"
 
 data Fields = Fields { description :: String }
-
 data Actions = Submit Fields | Toggle Int
 
 data Todo = Todo { description :: String, done :: Bool }
@@ -59,8 +58,10 @@ topStyle = style "font-family: sans-serif"
 
 todoItem (index, Todo { description, done }) = div
   [ text description
-  , onClick (Toggle index) $ typeAttr "checkbox" $
-      if done then checkedAttr "checked" $ input [] else input []
+  , onClick (Toggle index)
+      $ typeAttr "checkbox"
+      $ (if done then checkedAttr "checked" else checkedAttr "")
+      $ input []
   ]
 
 -- overall view
@@ -76,7 +77,7 @@ defaultFields = Fields { description="" }
 
 formHandler = effectHandler ([] :: [String]) action
   where
-    action newTodo state = pure $ (state, [Parent (Submit newTodo)])
+    action newTodo state = pure (state, [Parent (Submit newTodo)])
 
 addNewTodoForm =
   div

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -65,7 +65,9 @@ todoItem (index, Todo { description, done }) = div
   ]
 
 -- overall view
-view todos = div
+container = style "font-size: 24px" . div
+
+view todos = container
   [ div $ fmap todoItem (zip [0..] todos)
   , formHandler $ const addNewTodoForm
   ]

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -248,6 +248,10 @@ applyEvent eventBus fromEvent@FromEvent { message, location } component = case c
     children' <- mapM (applyEvent eventBus fromEvent) children
     pure $ Html kind children'
 
+  Attribute n cont -> do
+    child <- applyEvent eventBus fromEvent cont
+    pure $ Attribute n child
+
   Hide x -> do
     child <- applyEvent eventBus fromEvent x
     pure $ Hide child

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -130,13 +130,13 @@ renderAttributes attrs =
         Just (OnClick action) -> " action=" <> unpack (encode action)
         _                     -> ""
 
-      generics = filter isGeneric attrs
-      renderedGenerics = concatMap renderGeneric generics
-
       submit = find isSubmit attrs
       renderSubmit = case submit of
         Just (OnSubmit action) -> " action=" <> unpack (encode action)
         _                      -> ""
+
+      generics = filter isGeneric attrs
+      renderedGenerics = concatMap renderGeneric generics
   in
     renderStyle <> renderClick <> renderSubmit <> renderedGenerics
 
@@ -209,7 +209,9 @@ applyEvent eventBus fromEvent@FromEvent { message, location } component = case c
           then handler parsedAction state
           else pure (state, [])
 
-        atomically $ writeTChan eventBus $ FromEvent
+        -- although it doesn't break anything, only send this when the
+        -- locations match (cuts down on noise)
+        when (loc == location) $ atomically $ writeTChan eventBus $ FromEvent
           { event = "newState"
           , message = toJSON newState
           , location = loc
@@ -219,9 +221,6 @@ applyEvent eventBus fromEvent@FromEvent { message, location } component = case c
               (Parent event) -> FromEvent
                 { event = "internal"
                 , message = toJSON event
-                -- since locations are a list of indexes reversed,
-                -- getting the parent location is easy as dropping
-                -- the first item
                 , location = parentLocation
                 }
               (Self event) -> FromEvent


### PR DESCRIPTION
This also fixes #36 now that there's tests for it.

And fixed a bug where `Attribute`s were ignored in the traversal for events.
And fixed sending an unneeded `setState` event