### PR TITLE
Support for effect libraries at the top

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - scotty
 - hspec
 - time
+- freer-simple
 
 build-tools:
   - hspec-discover == 2.*

--- a/purview.cabal
+++ b/purview.cabal
@@ -44,6 +44,7 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
+    , freer-simple
     , hspec
     , raw-strings-qq
     , scotty
@@ -71,6 +72,7 @@ executable purview-exe
       aeson
     , base >=4.7 && <5
     , bytestring
+    , freer-simple
     , hspec
     , purview
     , raw-strings-qq
@@ -107,6 +109,7 @@ test-suite purview-test
       aeson
     , base >=4.7 && <5
     , bytestring
+    , freer-simple
     , hspec
     , purview
     , raw-strings-qq

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -31,7 +31,7 @@ data Change a = Update Location a | Delete Location a | Add Location a
 instance ToJSON a => ToJSON (Change a) where
   toEncoding = genericToEncoding defaultOptions
 
-diff :: Location -> Purview a -> Purview a -> [Change (Purview a)]
+diff :: Location -> Purview a m -> Purview a m -> [Change (Purview a m)]
 diff location oldGraph newGraph = case (oldGraph, newGraph) of
 
   (Html kind children, Html kind' children') ->

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -44,7 +44,7 @@ import           Diffing
 
 type Log m = String -> m ()
 
-run :: Log IO -> Purview a -> IO ()
+run :: Log IO -> Purview a m -> IO ()
 run log routes = do
   let port = 8001
   let settings = Warp.setPort port Warp.defaultSettings
@@ -55,7 +55,7 @@ run log routes = do
         (webSocketHandler log routes)
         requestHandler'
 
-requestHandler :: Purview a -> IO Wai.Application
+requestHandler :: Purview a m -> IO Wai.Application
 requestHandler routes =
   Sc.scottyApp $ do
     Sc.middleware $ Sc.gzip $ Sc.def { Sc.gzipFiles = Sc.GzipCompress }
@@ -77,7 +77,7 @@ requestHandler routes =
 -- handler, and then send the "setHtml" back downstream to tell it to replace
 -- the html with the new.
 --
-looper :: Log IO -> TChan FromEvent -> WS.Connection -> Purview a -> IO ()
+looper :: Log IO -> TChan FromEvent -> WS.Connection -> Purview a m -> IO ()
 looper log eventBus connection component = do
   message <- atomically $ readTChan eventBus
   log $ "received> " <> show message
@@ -114,7 +114,7 @@ webSocketMessageHandler eventBus websocketConnection = do
 
   webSocketMessageHandler eventBus websocketConnection
 
-webSocketHandler :: Log IO -> Purview a -> WS.ServerApp
+webSocketHandler :: Log IO -> Purview a m -> WS.ServerApp
 webSocketHandler log component pending = do
   putStrLn "ws connected"
   conn <- WS.acceptRequest pending

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 
@@ -44,15 +45,15 @@ import           Diffing
 
 type Log m = String -> m ()
 
-run :: Log IO -> Purview a m -> IO ()
-run log routes = do
+run :: Monad m => (m [FromEvent] -> IO [FromEvent]) -> Log IO -> Purview a m -> IO ()
+run runner log routes = do
   let port = 8001
   let settings = Warp.setPort port Warp.defaultSettings
   requestHandler' <- requestHandler routes
   Warp.runSettings settings
     $ WaiWs.websocketsOr
         WS.defaultConnectionOptions
-        (webSocketHandler log routes)
+        (webSocketHandler runner log routes)
         requestHandler'
 
 requestHandler :: Purview a m -> IO Wai.Application
@@ -77,18 +78,23 @@ requestHandler routes =
 -- handler, and then send the "setHtml" back downstream to tell it to replace
 -- the html with the new.
 --
-looper :: Log IO -> TChan FromEvent -> WS.Connection -> Purview a m -> IO ()
-looper log eventBus connection component = do
-  message <- atomically $ readTChan eventBus
+looper :: Monad m => (m [FromEvent] -> IO [FromEvent]) -> Log IO -> TChan FromEvent -> WS.Connection -> Purview a m -> IO ()
+looper runner log eventBus connection component = do
+  message@FromEvent { event } <- atomically $ readTChan eventBus
   log $ "received> " <> show message
 
   let
     (newTree, actions) = prepareGraph component
 
   -- apply can replace state
-  newTree' <- apply eventBus message newTree
+  let newTree' = case event of
+        "newState" -> applyNewState eventBus message newTree
+        _          -> newTree
+
+  newEvents <- runner $ runEvent message newTree'
 
   mapM_ (atomically . writeTChan eventBus) actions
+  mapM_ (atomically . writeTChan eventBus) newEvents
 
   let
     -- so I think here, we diff then render the diffs
@@ -102,7 +108,7 @@ looper log eventBus connection component = do
     connection
     (encode $ Event { event = "setHtml", message = renderedDiffs })
 
-  looper log eventBus connection newTree'
+  looper runner log eventBus connection newTree'
 
 webSocketMessageHandler :: TChan FromEvent -> WS.Connection -> IO ()
 webSocketMessageHandler eventBus websocketConnection = do
@@ -114,8 +120,8 @@ webSocketMessageHandler eventBus websocketConnection = do
 
   webSocketMessageHandler eventBus websocketConnection
 
-webSocketHandler :: Log IO -> Purview a m -> WS.ServerApp
-webSocketHandler log component pending = do
+webSocketHandler :: Monad m => (m [FromEvent] -> IO [FromEvent]) -> Log IO -> Purview a m -> WS.ServerApp
+webSocketHandler runner log component pending = do
   putStrLn "ws connected"
   conn <- WS.acceptRequest pending
 
@@ -125,4 +131,4 @@ webSocketHandler log component pending = do
 
   WS.withPingThread conn 30 (pure ()) $ do
     _ <- forkIO $ webSocketMessageHandler eventBus conn
-    looper log eventBus conn component
+    looper runner log eventBus conn component

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -5,27 +5,27 @@ import Prelude hiding (div)
 import Test.Hspec
 import Purview
 
-upButton :: Purview String
+upButton :: Purview String m
 upButton = onClick ("up" :: String) $ div [ text "up" ]
 
-downButton :: Purview String
+downButton :: Purview String m
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
-handler :: (Int -> Purview String) -> Purview a
+handler :: (Int -> Purview String m) -> Purview a m
 handler = messageHandler 0 action
   where
     action :: String -> Int -> (Int, [DirectedEvent String String])
     action "up" _ = (1, [])
     action _    _ = (0, [])
 
-counter :: Show a => a -> Purview String
+counter :: Show a => a -> Purview String m
 counter state = div
   [ upButton
   , text $ "count: " <> show state
   , downButton
   ]
 
-component :: Purview String
+component :: Purview String m
 component = handler counter
 
 event' :: String

--- a/src/experiments/Experiment15.hs
+++ b/src/experiments/Experiment15.hs
@@ -3,7 +3,7 @@
 module Experiment15 where
 
 import Prelude hiding (log)
-import Control.Monad.Writer
+-- import Control.Monad.Writer
 -- import Purview
 
 f :: Integer -> Integer

--- a/src/experiments/Experiment16.hs
+++ b/src/experiments/Experiment16.hs
@@ -14,6 +14,13 @@ import Control.Monad.Freer
 import Control.Monad.Freer.TH
 import Control.Monad.IO.Class
 
+data View action where
+  ActionHandler
+    :: state -- initial state
+    -> (action -> state -> IO state) -- action handler run by system for events
+    -> (state -> View action) -- continuation
+    -> View action
+
 data Temp a m where
   Box :: String -> m String -> Temp a m
 

--- a/src/experiments/Experiment16.hs
+++ b/src/experiments/Experiment16.hs
@@ -13,32 +13,201 @@ module Experiment16 where
 import Control.Monad.Freer
 import Control.Monad.Freer.TH
 import Control.Monad.IO.Class
+import           Control.Concurrent.STM.TChan
+import           Control.Monad.STM
+import           Control.Monad
+import           Control.Concurrent
+import Data.Typeable
 
-data View action where
+heck s = liftIO $ void . forkIO $ liftIO s
+
+{-
+
+Ok, what do I want?
+
+I want people to be able to use transformers easily for effects
+
+What haven't I tried?
+Rewriting apply in a monadic way (would that even fix anything?)
+
+What are you really saying with running effects at the top?
+
+Let's try this again
+
+-}
+
+data View action m where
   ActionHandler
-    :: state -- initial state
-    -> (action -> state -> IO state) -- action handler run by system for events
-    -> (state -> View action) -- continuation
-    -> View action
+    :: (Show state, Typeable state, Typeable action)
+    => state                         -- initial state
+    -> (action -> state -> m state) -- action handler run by system for events
+    -> (state -> View action m)        -- continuation
+    -> View action m
 
-data Temp a m where
-  Box :: String -> m String -> Temp a m
+  Nil :: View action m
+
+instance Show (View a m) where
+  show (ActionHandler state _ _) = show state
+
+reducer :: String -> String -> IO String
+reducer action state = pure $ state <> "hello"
+
+handler = ActionHandler "goodbye" reducer (const Nil)
+
+{-
+
+Alright, we have that part.  Now we need a tiny version of apply.
+
+-}
+
+apply :: (Typeable a, Monad m, MonadIO m) => View a m -> m (View a m)
+apply view = case view of
+  ActionHandler state handler cont -> do
+    newState <- case cast "" of
+      Just val -> handler val state
+      Nothing  -> error "fucka"
+
+{-
+
+This part is dead to me, time to refactor purview proper
+
+    _ <- forkIO $ do
+      newState <- case cast "" of
+        Just val ->
+          handler val state
+        Nothing  -> error "fucka"
+
+      liftIO $ print "done"
+-}
+
+    pure $ ActionHandler newState handler cont
+
+{-
+
+Cool.  Now back to what do you _mean_ when you say you want people to
+easily use effect systems?
+
+They should be per handler.  I want each handler to be able to say it
+needs specific effects.  And I want all the effects to be able to be
+stated at the top of the tree.  This means each part could also be
+tested, knowing exactly which effects it uses.
+
+so now we need an effect
+
+-}
 
 data Time r where
   GetTime :: Time String
 
 makeEffect ''Time
 
-test :: Member Time effs => Temp a (Eff effs)
-test = Box "" getTime
-
-useIt :: Member Time effs => Temp a (Eff effs) -> Eff effs String
-useIt (Box _ thing) = do
-  y <- thing
-  pure (y <> "more")
-
-runPureTime :: Eff (Time ': effs) ~> Eff effs
-runPureTime = interpret $ \case
+runPureTime :: LastMember IO effs => Eff (Time ': effs) a -> Eff effs a
+runPureTime = interpretM $ \case
   GetTime -> pure "123"
 
-feh = run . runPureTime $ useIt test
+{-
+
+And a handler that uses that effect
+
+-}
+
+effectReducer :: Member Time effs => String -> String -> Eff effs String
+effectReducer action state = getTime
+
+{-
+
+can we use this handler in a test?
+
+-}
+
+test = do
+  val <- runM . runPureTime $ effectReducer "" ""
+  print $ val == "123"
+
+{-
+
+Super.
+
+And now we plug it into a handler
+
+-}
+
+effectHandler :: Member Time effs => View String (Eff effs)
+effectHandler = ActionHandler "goodbye" effectReducer (const Nil)
+
+{-
+
+Alright.  Now we need to make this work with apply.
+
+-}
+
+wonderful = runM . runPureTime $ apply effectHandler
+
+{-
+
+We almost have it.  Now I just need to find a way for IO to get involved for the
+void . forkIO.
+
+-}
+
+{-
+
+It looks like the void . forkIO is impossible.
+
+-}
+
+-- data Temp a m where
+--   Box :: (String -> m String) -> Temp a m
+--
+-- data Time r where
+--   GetTime :: Time String
+--
+-- makeEffect ''Time
+--
+-- -- test :: Member Time effs => Temp a (Eff effs)
+-- test = Box (const getTime)
+--
+-- useIt :: Member Time effs => Temp a (Eff effs) -> Eff effs String
+-- useIt (Box thing) = do
+--   y <- thing ""
+--   pure (y <> "more")
+--
+-- runPureTime :: Eff (Time ': effs) ~> Eff effs
+-- runPureTime = interpret $ \case
+--   GetTime -> pure "123"
+--
+-- -- what = runM . runPureTime $ do
+-- --   print ""
+-- --   useIt test
+-- --   pure ()
+--
+-- hmm :: Monad m => Temp a m -> m ()
+-- hmm (Box action) = do
+--   action ""
+--   pure ()
+--
+-- flub = hmm test
+--
+-- xyz = id
+--
+-- t = xyz test
+--
+-- -- func = do
+-- --   test
+--
+-- overlap :: Temp a m -> IO ()
+-- overlap x = undefined
+--
+-- -- applyEvent :: Member Time effs => Temp a (Eff effs) -> IO (Temp a (Eff effs))
+-- -- applyEvent view = case view of
+-- --   Box fn -> do
+-- --     void . forkIO $ do
+-- --       fn ""
+-- --       pure ()
+-- --
+-- --     pure (Box fn)
+-- --
+-- -- heck = applyEvent test
+--
+-- feh :: IO (String)
+-- feh = runM . runPureTime $ useIt test

--- a/src/experiments/Experiment16.hs
+++ b/src/experiments/Experiment16.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+
+-- |
+
+module Experiment16 where
+
+import Control.Monad.Freer
+import Control.Monad.Freer.TH
+import Control.Monad.IO.Class
+
+data Temp a m where
+  Box :: String -> m String -> Temp a m
+
+data Time r where
+  GetTime :: Time String
+
+makeEffect ''Time
+
+test :: Member Time effs => Temp a (Eff effs)
+test = Box "" getTime
+
+useIt :: Member Time effs => Temp a (Eff effs) -> Eff effs String
+useIt (Box _ thing) = do
+  y <- thing
+  pure (y <> "more")
+
+runPureTime :: Eff (Time ': effs) ~> Eff effs
+runPureTime = interpret $ \case
+  GetTime -> pure "123"
+
+feh = run . runPureTime $ useIt test


### PR DESCRIPTION
This turned into a pretty large refactor.

This make it so effectHandler aren't limited just "IO".  Whether this was a "good idea" or not remains to be seen.  Haskell taught me a few things while fighting to get some kind of `m a -> IO a` to work, in the end it was much easier to go with what it was telling me and refactoring.

Experiment16 contains some good things about the thought process behind it.

I'm still not entirely sure it's a great change, would it have been better to just leave it IO and requiring the `run . runPureTime` kind of thing per handler?  ie
```
reducer :: Member Time effs => action -> state -> Eff effs state
reducer "getTime" state = Just <$> getTime

handler = effectHandler Nothing (runM . runPureTime $ reducer)
```
or something like that.  Shit.