### PR TITLE
Enable reloading the full page on websocket reconnect

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -171,7 +171,7 @@ view todos = container
   ]
 
 -- submission form
-submitButton = typeAttr "submit" $ button [ text "submit?" ]
+submitButton = typeAttr "submit" $ button [ text "submit" ]
 
 defaultFields = Fields { description="" }
 
@@ -193,7 +193,7 @@ top = effectHandler () reducer
   where
     reducer _ _ = pure ((), [])
 
-main = Purview.run (defaultConfiguration { component=top . const $ handler view })
+main = Purview.run (defaultConfiguration { component=top . const $ handler view, devMode=True })
 
 -------------------------
 -- Using Input Example --

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -171,7 +171,7 @@ view todos = container
   ]
 
 -- submission form
-submitButton = typeAttr "submit" $ button [ text "submit" ]
+submitButton = typeAttr "submit" $ button [ text "submit?" ]
 
 defaultFields = Fields { description="" }
 
@@ -193,7 +193,7 @@ top = effectHandler () reducer
   where
     reducer _ _ = pure ((), [])
 
-main = Purview.run (defaultConfiguration { component=top $ const $ handler view })
+main = Purview.run (defaultConfiguration { component=top . const $ handler view })
 
 -------------------------
 -- Using Input Example --
@@ -268,34 +268,32 @@ main = Purview.run (defaultConfiguration { component=top $ const $ handler view 
 --
 -- handler = messageHandler (0 :: Int) action
 --   where
---     action Up   state = state + 1
---     action Down state = state - 1
+--     action Up   state = (state + 1, [])
+--     action Down state = (state - 1, [])
 --
--- handler' = messageHandler (0 :: Int) action
---   where
---     action Port      state = state + 1
---     action Starboard state = state - 1
+-- -- handler' = messageHandler (0 :: Int) action
+-- --   where
+-- --     action Port      state = (state + 1, [])
+-- --     action Starboard state = (state - 1, [])
+-- --
+-- -- component' = handler' (\state -> div [ text "" ])
 --
--- component' = handler' (\state -> div [ text "" ])
---
--- counter :: Int -> Purview Direction
+-- counter :: Int -> Purview Direction Direction m
 -- counter state = div
 --   [ upButton
 --   , text $ "count: " <> show state
 --   , downButton
 --   ]
 --
--- component = handler counter
+-- view = handler counter
 --
 -- multiCounter = div
---   [ component
---   , component
---   , component
+--   [ view
+--   , view
+--   , view
 --   ]
 --
--- logger = print
---
--- main = run logger component
+-- main = Purview.run defaultConfiguration { component=view }
 
 
 -------------------------

--- a/package.yaml
+++ b/package.yaml
@@ -32,8 +32,6 @@ dependencies:
 - wai-extra
 - websockets
 - scotty
-- time
-- freer-simple
 
 build-tools:
   - hspec-discover == 2.*
@@ -61,6 +59,8 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - purview
+    - time
+    - freer-simple
 
   purview-perf-test:
     main: Criterion.hs

--- a/package.yaml
+++ b/package.yaml
@@ -84,3 +84,4 @@ tests:
     - purview
     - QuickCheck
     - hspec
+    - time

--- a/purview.cabal
+++ b/purview.cabal
@@ -138,6 +138,7 @@ test-suite purview-test
     , scotty
     , stm
     , text
+    , time
     , wai
     , wai-extra
     , wai-websockets

--- a/purview.cabal
+++ b/purview.cabal
@@ -45,12 +45,10 @@ library
       aeson
     , base >=4.7 && <5
     , bytestring
-    , freer-simple
     , raw-strings-qq
     , scotty
     , stm
     , text
-    , time
     , wai
     , wai-extra
     , wai-websockets
@@ -100,13 +98,11 @@ executable purview-perf-test
     , base >=4.7 && <5
     , bytestring
     , criterion
-    , freer-simple
     , purview
     , raw-strings-qq
     , scotty
     , stm
     , text
-    , time
     , wai
     , wai-extra
     , wai-websockets
@@ -136,14 +132,12 @@ test-suite purview-test
     , aeson
     , base >=4.7 && <5
     , bytestring
-    , freer-simple
     , hspec
     , purview
     , raw-strings-qq
     , scotty
     , stm
     , text
-    , time
     , wai
     , wai-extra
     , wai-websockets

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -13,6 +13,16 @@ data Attributes action where
   Style :: String -> Attributes action
   Generic :: String -> String -> Attributes action
 
+instance Eq (Attributes action) where
+  (Style a) == (Style b) = a == b
+  (Style _) == _ = False
+
+  (On kind action) == (On kind' action') = kind == kind' && encode action == encode action'
+  (On _ _) == _ = False
+
+  (Generic name value) == (Generic name' value') = name == name' && value == value'
+  (Generic _ _) == _ = False
+
 type Identifier = Maybe [Int]
 type ParentIdentifier = Identifier
 
@@ -49,7 +59,11 @@ data Purview parentAction action m where
 
 instance Show (Purview parentAction action m) where
   show (EffectHandler parentLocation location state _action cont) =
-    "EffectHandler " <> show parentLocation <> " " <> show location <> " " <> show (cont state)
+    "EffectHandler "
+    <> show parentLocation <> " "
+    <> show location <> " "
+    <> show (encode state) <> " "
+    <> show (cont state)
   show (Once _ hasRun cont) = "Once " <> show hasRun <> " " <> show cont
   show (Attribute _attrs cont) = "Attr " <> show cont
   show (Text str) = show str

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -6,8 +6,9 @@ module EventHandling where
 import           Control.Concurrent.STM.TChan
 import           Data.Aeson
 
-import Events
-import Component
+import           Events
+import           Component
+
 
 {-|
 

--- a/tests/EventHandlingSpec.hs
+++ b/tests/EventHandlingSpec.hs
@@ -95,7 +95,7 @@ spec = parallel $ do
 
     it "works for setting state across many different trees" $
       property $ \x -> do
-        let event = FromEvent { event="newState", message="up", location=Nothing }
+        let event = FromEvent { event="newState", message="up", location=Just [] }
         chan <- newTChanIO
 
         component <- apply chan event (x :: Purview String String IO)

--- a/tests/PrepareTreeSpec.hs
+++ b/tests/PrepareTreeSpec.hs
@@ -39,7 +39,7 @@ spec = parallel $ do
 
       show (fst (prepareTree component))
         `shouldBe`
-        "EffectHandler Just [] Just [] Once True div [  \"Nothing\" Attr div [  \"check time\" ]  ] "
+        "EffectHandler Just [] Just [] \"null\" Once True div [  \"Nothing\" Attr div [  \"check time\" ]  ] "
 
       length (snd (prepareTree component))
         `shouldBe`
@@ -111,7 +111,7 @@ spec = parallel $ do
 
       show graphWithLocation
         `shouldBe`
-        "div [  Hide EffectHandler Just [] Just [0] \"\" Hide EffectHandler Just [] Just [1] \"\" ] "
+        "div [  Hide EffectHandler Just [] Just [0] \"null\" \"\" Hide EffectHandler Just [] Just [1] \"null\" \"\" ] "
 
     it "assigns a different location to nested handlers" $ do
       let
@@ -129,7 +129,7 @@ spec = parallel $ do
 
         graphWithLocation = fst (prepareTree component)
 
-      show graphWithLocation `shouldBe` "Hide EffectHandler Just [] Just [] Hide EffectHandler Just [] Just [0] \"\""
+      show graphWithLocation `shouldBe` "Hide EffectHandler Just [] Just [] \"null\" Hide EffectHandler Just [] Just [0] \"null\" \"\""
 
 
 main :: IO ()


### PR DESCRIPTION
With the follow command, and `devMode` set to `True`, the full page is sent over on websocket reconnects.

`ghcid --command 'stack ghci examples/Main.hs' --test :main`

Absolutely have to add that to the readme.  I'm extremely happy with this for now.

Fixes #31 in a pretty reasonable way.  Something that also keeps states between updates can come later :)

Also fixed a bug with diffing in a very meh way, I'll open a new ticket to do diffing more correctly.