### PR TITLE
Trying to keep diffing "simple"

### DIFF
--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -3,8 +3,9 @@ module DiffingSpec where
 import Prelude hiding (div)
 import Test.Hspec
 
-import Diffing
+import PrepareTree
 import Purview
+import Diffing
 
 type DefaultAction = DirectedEvent String String
 
@@ -18,21 +19,21 @@ spec = parallel $ do
         oldTree = div [ text "night" ]
         newTree = div [ text "morning" ]
 
-      diff [] oldTree newTree `shouldBe` [Update [0] (text "morning")]
+      diff Nothing [] oldTree newTree `shouldBe` [Update [0] (text "morning")]
 
     it "can do a nested update" $ do
       let
         oldTree = div [ div [ text "night" ] ]
         newTree = div [ div [ text "morning" ] ]
 
-      diff [] oldTree newTree `shouldBe` [Update [0, 0] (text "morning")]
+      diff Nothing [] oldTree newTree `shouldBe` [Update [0, 0] (text "morning")]
 
     it "says to update the whole underlying tree on added div" $ do
       let
         oldTree = div [ text "night" ]
         newTree = div [ div [ text "morning" ] ]
 
-      diff [] oldTree newTree `shouldBe` [Update [0] (div [ text "morning" ])]
+      diff Nothing [] oldTree newTree `shouldBe` [Update [0] (div [ text "morning" ])]
 
     describe "message handlers" $ do
 --      it "doesn't diff handler children if the state is the same" $ do
@@ -52,7 +53,7 @@ spec = parallel $ do
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
-        diff [] oldTree newTree `shouldBe`
+        diff Nothing [] oldTree newTree `shouldBe`
           [ Update [0] (handler2 (const (text "this is different")))
           , Update [0, 0] (text "this is different")
           ]
@@ -75,7 +76,7 @@ spec = parallel $ do
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
-        diff [] oldTree newTree `shouldBe`
+        diff Nothing [] oldTree newTree `shouldBe`
           [ Update [0] (handler2 (const (text "this is different")))
           , Update [0, 0] (text "this is different")
           ]
@@ -85,12 +86,16 @@ spec = parallel $ do
           handler1 :: (String -> Purview String action IO) -> Purview String action IO
           handler1 = effectHandler "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           handler2 = effectHandler "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          oldTree = div [ handler1 . const $ handler1 (const (text "the original")) ]
-          newTree = div [ handler1 . const $ handler2 (const (text "this is different")) ]
+          oldTree = fst . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
+          newTree = fst . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 
-        diff [] oldTree newTree `shouldBe`
-          [ Update [0, 0] (handler2 (const (text "this is different")))
-          , Update [0, 0, 0] (text "this is different")
+        diff (Just [0, 0]) [] oldTree newTree `shouldBe`
+          [ Update [0, 0] (Hide $ EffectHandler
+                            (Just [0])
+                            (Just [0, 0])
+                            "different state"
+                            (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+                            (const (text "this is different")))
           ]
 
 

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -39,7 +39,7 @@ eventLoop
   -> Purview parentAction action m
   -> IO ()
 eventLoop devMode runner log eventBus connection component = do
-  message@FromEvent { event } <- atomically $ readTChan eventBus
+  message@FromEvent { event, location } <- atomically $ readTChan eventBus
   log $ "received> " <> show message
 
   let
@@ -63,7 +63,7 @@ eventLoop devMode runner log eventBus connection component = do
 
   let
     -- collect diffs
-    diffs = diff [0] component newTree'
+    diffs = diff location [0] component newTree'
     -- for now it's just "Update", which the javascript handles as replacing
     -- the html beneath the handler.  I imagine it could be more exact, with
     -- Delete / Create events.


### PR DESCRIPTION
This is so diffing is still cut off at the handler level, ostensibly to keep diffing simple and not having to deal with exact diffs (yet).