### PR TITLE
Apply state change in event loop

### DIFF
--- a/examples/EventOrderingCheck.hs
+++ b/examples/EventOrderingCheck.hs
@@ -1,0 +1,41 @@
+module EventOrdering where
+
+import Prelude hiding (div)
+import Control.Concurrent
+import Purview
+
+
+{-
+
+This is to test that running the new state function is happening at the
+correct time.
+
+To run the test:
+1. Hit "slow"
+2. Hit "fast"
+
+Counter should increment immediately after hitting "fast", and 5 seconds
+later the count should be increased by 1 when "slow" completes.  The bug
+would be the count is overwritten by "slow" completing.
+
+-}
+
+reducer "fast" state = pure (\state -> state + 1, [])
+reducer "slow" state = do
+  threadDelay (5 * 1000000)
+  pure (\state -> state + 1, [])
+
+handler = effectHandler (0 :: Int) reducer
+
+checkButtonSlow :: Purview parentAction String m
+checkButtonSlow = onClick ("slow" :: String) $ div [ text "slow" ]
+
+checkButtonFast = onClick ("fast" :: String) $ div [ text "fast" ]
+
+combined = handler $ \state -> div
+  [ p [ text (show state) ]
+  , checkButtonSlow
+  , checkButtonFast
+  ]
+
+main = run defaultConfiguration { component=combined }

--- a/purview.cabal
+++ b/purview.cabal
@@ -74,6 +74,7 @@ executable purview-exe
   main-is: Counter.hs
   other-modules:
       AlgebraicEffects
+      EventOrderingCheck
       ExpandingList
       GettingInput
       ServerTime

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -73,7 +73,7 @@ data Purview parentAction action m where
 
   Once
     :: (ToJSON action)
-    => ((action -> FromEvent) -> FromEvent)
+    => ((action -> Event) -> Event)
     -> Bool  -- has run
     -> Purview parentAction action m
     -> Purview parentAction action m
@@ -206,7 +206,7 @@ to send an event up to it, and it will only be sent once.
 -}
 once
   :: ToJSON action
-  => ((action -> FromEvent) -> FromEvent)
+  => ((action -> Event) -> Event)
   -> Purview parentAction action m
   -> Purview parentAction action m
 once sendAction = Once sendAction False

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -23,19 +23,9 @@ applyNewState
 applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case component of
   EffectHandler ploc loc state handler cont -> case cast newStateFn of
     Just newStateFn' -> EffectHandler ploc loc (newStateFn' state) handler cont
-    -- TODO: This needs to continue down the tree
-    Nothing -> EffectHandler ploc loc state handler cont
-
---    case fromJSON message of
---    Success newState -> do
---      if loc == location
---        then EffectHandler ploc loc newState handler cont
---        else
---          let cont' = fmap (applyNewState fromEvent) cont
---          in EffectHandler ploc loc state handler cont'
---    Error _ ->
---      let cont' = fmap (applyNewState fromEvent) cont
---      in EffectHandler ploc loc state handler cont'
+    Nothing ->
+      let children = fmap (applyNewState fromEvent) cont
+      in EffectHandler ploc loc state handler children
 
   Hide x ->
     let

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -39,7 +39,6 @@ in a non-forked fashioned.  If you try void . forkIO you end up back in m a -> I
 hell.
 
 -}
-
 apply :: MonadIO m => TChan Event -> Event -> Purview parentAction action m -> m (Purview parentAction action m)
 apply eventBus newStateEvent@StateChangeEvent {} component =
   pure $ applyNewState newStateEvent component

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -40,8 +40,10 @@ hell.
 
 -}
 
-apply :: MonadIO m => TChan FromEvent -> FromEvent -> Purview parentAction action m -> m (Purview parentAction action m)
-apply eventBus fromEvent@FromEvent {event=eventKind} component =
+apply :: MonadIO m => TChan Event -> Event -> Purview parentAction action m -> m (Purview parentAction action m)
+apply eventBus newStateEvent@StateChangeEvent {} component =
+  pure $ applyNewState newStateEvent component
+apply eventBus fromEvent@Event {event=eventKind} component =
   case eventKind of
     "newState" -> pure $ applyNewState fromEvent component
     _          -> do
@@ -71,15 +73,13 @@ spec = parallel $ do
 
       chan <- newTChanIO
 
-      let event' = FromEvent { event="click", message="up", location=Nothing }
+      let event' = Event { event="click", message="up", location=Nothing }
 
       appliedHandler <- apply chan event' handler
 
       stateEvent <- atomically $ readTChan chan
 
-      stateEvent
-        `shouldBe`
-        FromEvent { event="newState", message=Number 1, location=Nothing }
+      show stateEvent `shouldBe` show (StateChangeEvent (id :: Int -> Int) Nothing)
 
       afterState <- apply chan stateEvent appliedHandler
 
@@ -89,7 +89,7 @@ spec = parallel $ do
 
     it "works for clicks across many different trees" $
       property $ \x -> do
-        let event = FromEvent { event="click", message="up", location=Nothing }
+        let event = Event { event="click", message="up", location=Nothing }
         chan <- newTChanIO
 
         component <- apply chan event (x :: Purview String String IO)
@@ -97,7 +97,7 @@ spec = parallel $ do
 
     it "works for setting state across many different trees" $
       property $ \x -> do
-        let event = FromEvent { event="newState", message="up", location=Just [] }
+        let event = Event { event="newState", message="up", location=Just [] }
         chan <- newTChanIO
 
         component <- apply chan event (x :: Purview String String IO)
@@ -124,7 +124,7 @@ spec = parallel $ do
 
       chan <- newTChanIO
 
-      let event' = FromEvent { event="click", message=toJSON Up, location=Nothing }
+      let event' = Event { event="click", message=toJSON Up, location=Nothing }
 
       appliedHandler <- apply chan event' handler
 
@@ -149,14 +149,14 @@ spec = parallel $ do
 
       chan <- newTChanIO
 
-      let event0 = FromEvent { event="init", message="init", location=Nothing }
+      let event0 = Event { event="init", message="init", location=Nothing }
 
       appliedHandler0 <- apply chan event0 handler
       render appliedHandler0
         `shouldBe`
         "<div handler=\"null\">0</div>"
 
-      let event1 = FromEvent { event="init", message=toJSON Up, location=Nothing }
+      let event1 = Event { event="init", message=toJSON Up, location=Nothing }
 
       appliedHandler1 <- apply chan event1 appliedHandler0
 
@@ -196,15 +196,15 @@ spec = parallel $ do
 
       let
         locatedGraph = fst $ prepareTree component
-        event1 = FromEvent { event="click", message=toJSON Up, location=Just [1, 0] }
+        event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
 
       afterEvent1 <- apply chan event1 locatedGraph
 
       receivedEvent1 <- atomically $ readTChan chan
-      receivedEvent1 `shouldBe` FromEvent {event = "newState", message = Number 1.0, location = Just [1,0]}
+      show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
 
       receivedEvent2 <- atomically $ readTChan chan
-      receivedEvent2 `shouldBe` FromEvent {event = "internal", message = String "hello", location = Just []}
+      receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
 
     describe "sending events" $ do
 
@@ -235,16 +235,16 @@ spec = parallel $ do
 
         render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
 
-        let event1 = FromEvent { event="click", message=toJSON Up, location=Just [1, 0] }
+        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
 
         afterEvent1 <- apply chan event1 locatedGraph
 
         receivedEvent1 <- atomically $ readTChan chan
-        receivedEvent1 `shouldBe` FromEvent {event = "newState", message = Number 1.0, location = Just [1,0]}
+        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
 
         receivedEvent2 <- atomically $ readTChan chan
         -- correctly targeted to the parent
-        receivedEvent2 `shouldBe` FromEvent {event = "internal", message = String "hello", location = Just []}
+        receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
 
 
       it "can send an event to self" $ do
@@ -274,16 +274,16 @@ spec = parallel $ do
 
         render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
 
-        let event1 = FromEvent { event="click", message=toJSON Up, location=Just [1, 0] }
+        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
 
         afterEvent1 <- apply chan event1 locatedGraph
 
         receivedEvent1 <- atomically $ readTChan chan
-        receivedEvent1 `shouldBe` FromEvent {event = "newState", message = Number 1.0, location = Just [1,0]}
+        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
 
         receivedEvent2 <- atomically $ readTChan chan
         -- correctly targeted to self
-        receivedEvent2 `shouldBe` FromEvent {event = "internal", message = String "Down", location = Just [1,0]}
+        receivedEvent2 `shouldBe` Event {event = "internal", message = String "Down", location = Just [1,0]}
 
 
 main :: IO ()

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -42,7 +42,7 @@ eventLoop devMode runner log eventBus connection component = do
   message <- atomically $ readTChan eventBus
   -- message@FromEvent { event, location } <- atomically $ readTChan eventBus
 
-  log $ "received> " <> show message
+  when devMode $ log $ "received> " <> show message
 
   let
     -- this collects any actions that should run once and sets them
@@ -79,7 +79,7 @@ eventLoop devMode runner log eventBus connection component = do
     -- Delete / Create events.
     renderedDiffs = fmap (\(Update location graph) -> Update location (render graph)) diffs
 
-  log $ "sending> " <> show renderedDiffs
+  when devMode $ log $ "sending> " <> show renderedDiffs
 
   WebSockets.sendTextData
     connection

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -5,6 +7,7 @@
 module Events where
 
 import           Data.Text (Text)
+import           Data.Typeable
 import           Data.Aeson
 import           GHC.Generics
 
@@ -26,6 +29,22 @@ instance FromJSON FromEvent where
 
 instance ToJSON m => ToJSON (Event m) where
   toEncoding = genericToEncoding defaultOptions
+
+data StateChangeEvent where
+  StateChangeEvent
+    :: ( Eq state
+       , Typeable state
+       , ToJSON state
+       , FromJSON state)
+    => (state -> state) -> Maybe [Int] -> StateChangeEvent
+
+instance Show StateChangeEvent where
+  show (StateChangeEvent fn location) = "StateChangeEvent " <> show location
+
+-- data StateChangeEvent = StateChangeEvent
+--   { event :: (state -> state)
+--   , location :: Maybe [Int]
+--   }
 
 {-|
 

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -11,10 +11,13 @@ import           Data.Typeable
 import           Data.Aeson
 import           GHC.Generics
 
-data Event m = Event
+data ForFrontEndEvent m = ForFrontEndEvent
   { event :: Text
   , message :: m
   } deriving (Generic, Show)
+
+instance ToJSON m => ToJSON (ForFrontEndEvent m) where
+  toEncoding = genericToEncoding defaultOptions
 
 data FromEvent = FromEvent
   { event :: Text
@@ -26,9 +29,6 @@ instance FromJSON FromEvent where
   parseJSON (Object o) =
       FromEvent <$> o .: "event" <*> (o .: "message") <*> o .: "location"
   parseJSON _ = error "fail"
-
-instance ToJSON m => ToJSON (Event m) where
-  toEncoding = genericToEncoding defaultOptions
 
 data StateChangeEvent where
   StateChangeEvent

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -17,12 +17,16 @@ It also assigns a location to message and effect handlers.
 
 -}
 
-prepareTree :: Purview parentAction action m -> (Purview parentAction action m, [FromEvent])
+prepareTree :: Purview parentAction action m -> (Purview parentAction action m, [Event])
 prepareTree = prepareTree' [] []
 
 type Location = [Int]
 
-prepareTree' :: Location -> Location -> Purview parentAction action m -> (Purview parentAction action m, [FromEvent])
+prepareTree'
+  :: Location
+  -> Location
+  -> Purview parentAction action m
+  -> (Purview parentAction action m, [Event])
 prepareTree' parentLocation location component = case component of
   Attribute attrs cont ->
     let result = prepareTree' parentLocation location cont
@@ -42,7 +46,7 @@ prepareTree' parentLocation location component = case component of
 
   Once effect hasRun cont ->
     let send message =
-          FromEvent
+          Event
             { event = "once"
             , message = toJSON message
             , location = Just location

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -121,6 +121,7 @@ import           Events
 import           PrepareTree
 import           Rendering
 import           Wrapper
+import Network.Wai.Middleware.RequestLogger (mkRequestLogger)
 
 type Log m = String -> m ()
 
@@ -180,8 +181,6 @@ requestHandler :: Purview parentAction action m -> Text -> [HtmlEventHandler] ->
 requestHandler routes htmlHead htmlEventHandlers =
   Sc.scottyApp $ do
     Sc.middleware $ Sc.gzip $ Sc.def { Sc.gzipFiles = Sc.GzipCompress }
-
-    -- Sc.middleware S.logStdoutDev
 
     Sc.get "/"
       $ Sc.html

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -111,6 +111,7 @@ import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 import           Data.Aeson
 
+import           Control.Monad (when)
 import           Control.Concurrent.STM.TChan
 import           Control.Monad.STM
 import           Control.Concurrent
@@ -208,7 +209,7 @@ webSocketHandler
   -> Purview parentAction action m
   -> WebSocket.ServerApp
 webSocketHandler devMode runner log component pending = do
-  putStrLn "ws connected"
+  when devMode $ putStrLn "ws connected"
   conn <- WebSocket.acceptRequest pending
 
   eventBus <- newTChanIO


### PR DESCRIPTION
This is to fix #77.

The time of applying the state change function is moved from using the stale state, to where events are read.

The following should now work:
1. Long running handler is kicked off
2. Short handler is kicked off
3. State is updated by short handler
4. State is updated by long running handler and doesn't overwrite the state change the short handler did

It's also the last thing to fix besides making that diagram in the READ more sensible.