### PR TITLE
Remove extra parent action from AST

### DIFF
--- a/examples/EventOrderingCheck.hs
+++ b/examples/EventOrderingCheck.hs
@@ -27,9 +27,10 @@ reducer "slow" state = do
 
 handler = effectHandler (0 :: Int) reducer
 
-checkButtonSlow :: Purview parentAction String m
+checkButtonSlow :: Purview String m
 checkButtonSlow = onClick ("slow" :: String) $ div [ text "slow" ]
 
+checkButtonFast :: Purview String m
 checkButtonFast = onClick ("fast" :: String) $ div [ text "fast" ]
 
 combined = handler $ \state -> div

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -78,8 +78,6 @@ data Purview event m where
     -> Purview event m
     -> Purview event m
 
-  Hide :: Purview newEvent m -> Purview any m
-
 instance Show (Purview event m) where
   show (EffectHandler parentLocation location state _event cont) =
     "EffectHandler "
@@ -93,7 +91,6 @@ instance Show (Purview event m) where
   show (Html kind children) =
     kind <> " [ " <> concatMap ((<>) " " . show) children <> " ] "
   show (Value value) = show value
-  show (Hide a) = "Hide " <> show a
 
 instance Eq (Purview event m) where
   a == b = show a == show b
@@ -196,7 +193,7 @@ effectHandler
   -- ^ continuation
   -> Purview parentEvent m
 effectHandler state handler =
-  Hide . EffectHandler Nothing Nothing state handler
+  EffectHandler Nothing Nothing state handler
 
 {-|
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -15,19 +15,19 @@ Attributes are collected until an 'HTML' constructor is hit, where they
 are applied during rendering.
 
 -}
-data Attributes action where
-  On :: ToJSON action => String -> action -> Attributes action
+data Attributes event where
+  On :: ToJSON event => String -> event -> Attributes event
   -- ^ part of creating handlers for different events, e.g. On "click"
-  Style :: String -> Attributes action
+  Style :: String -> Attributes event
   -- ^ inline css
-  Generic :: String -> String -> Attributes action
+  Generic :: String -> String -> Attributes event
   -- ^ for creating new Attributes to put on HTML, e.g. Generic "type" "radio" for type="radio".
 
-instance Eq (Attributes action) where
+instance Eq (Attributes event) where
   (Style a) == (Style b) = a == b
   (Style _) == _ = False
 
-  (On kind action) == (On kind' action') = kind == kind' && encode action == encode action'
+  (On kind event) == (On kind' event') = kind == kind' && encode event == encode event'
   (On _ _) == _ = False
 
   (Generic name value) == (Generic name' value') = name == name' && value == value'
@@ -43,17 +43,17 @@ that you have to use these directly, but it may be useful to better understand
 what's happening behind the scenes.
 
 -}
-data Purview parentAction action m where
-  Attribute :: Attributes action -> Purview parentAction action m -> Purview parentAction action m
-  Text :: String -> Purview parentAction action m
-  Html :: String -> [Purview parentAction action m] -> Purview parentAction action m
-  Value :: Show a => a -> Purview parentAction action m
+data Purview event m where
+  Attribute :: Attributes event -> Purview event m -> Purview event m
+  Text :: String -> Purview event m
+  Html :: String -> [Purview event m] -> Purview event m
+  Value :: Show a => a -> Purview event m
 
   -- | All the handlers boil down to this one.
   EffectHandler
-    :: ( FromJSON newAction
-       , ToJSON newAction
-       , ToJSON parentAction
+    :: ( FromJSON newEvent
+       , ToJSON newEvent
+       , ToJSON parentEvent
        , FromJSON state
        , ToJSON state
        , Typeable state
@@ -65,23 +65,23 @@ data Purview parentAction action m where
     -- ^ The location of this effect handler (provided by prepareTree)
     -> state
     -- ^ The initial state
-    -> (newAction-> state -> m (state -> state, [DirectedEvent parentAction newAction]))
-    -- ^ Receive an action, change the state, and send messages
-    -> (state -> Purview newAction any m)
+    -> (newEvent-> state -> m (state -> state, [DirectedEvent parentEvent newEvent]))
+    -- ^ Receive an event, change the state, and send messages
+    -> (state -> Purview newEvent m)
     -- ^ Continuation
-    -> Purview parentAction newAction m
+    -> Purview parentEvent m
 
   Once
-    :: (ToJSON action)
-    => ((action -> Event) -> Event)
+    :: (ToJSON event)
+    => ((event -> Event) -> Event)
     -> Bool  -- has run
-    -> Purview parentAction action m
-    -> Purview parentAction action m
+    -> Purview event m
+    -> Purview event m
 
-  Hide :: Purview parentAction newAction m -> Purview parentAction any m
+  Hide :: Purview newEvent m -> Purview any m
 
-instance Show (Purview parentAction action m) where
-  show (EffectHandler parentLocation location state _action cont) =
+instance Show (Purview event m) where
+  show (EffectHandler parentLocation location state _event cont) =
     "EffectHandler "
     <> show parentLocation <> " "
     <> show location <> " "
@@ -95,7 +95,7 @@ instance Show (Purview parentAction action m) where
   show (Value value) = show value
   show (Hide a) = "Hide " <> show a
 
-instance Eq (Purview parentAction action m) where
+instance Eq (Purview event m) where
   a == b = show a == show b
 
 {-|
@@ -115,10 +115,10 @@ For example, let's say you want to make a button that switches between saying
 
 -}
 simpleHandler
-  :: ( FromJSON action
+  :: ( FromJSON event
      , FromJSON state
-     , ToJSON action
-     , ToJSON parentAction
+     , ToJSON event
+     , ToJSON parentEvent
      , ToJSON state
      , Typeable state
      , Eq state
@@ -126,13 +126,13 @@ simpleHandler
      )
   => state
   -- ^ The initial state
-  -> (action -> state -> state)
-  -- ^ The reducer, or how the state should change for an action
-  -> (state -> Purview action any1 m)
+  -> (event -> state -> state)
+  -- ^ The reducer, or how the state should change for an event
+  -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
-  -> Purview parentAction any2 m
+  -> Purview parentEvent m
 simpleHandler state handler =
-  effectHandler state (\action state -> pure (const $ handler action state, []))
+  effectHandler state (\event state -> pure (const $ handler event state, []))
 
 {-|
 
@@ -143,10 +143,10 @@ their own threads.
 
 -}
 messageHandler
-  :: ( FromJSON action
+  :: ( FromJSON event
      , FromJSON state
-     , ToJSON action
-     , ToJSON parentAction
+     , ToJSON event
+     , ToJSON parentEvent
      , ToJSON state
      , Typeable state
      , Eq state
@@ -154,13 +154,13 @@ messageHandler
      )
   => state
   -- ^ initial state
-  -> (action -> state -> (state -> state, [DirectedEvent parentAction action]))
+  -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))
   -- ^ reducer
-  -> (state -> Purview action any1 m)
+  -> (state -> Purview event m)
   -- ^ continuation
-  -> Purview parentAction any2 m
+  -> Purview parentEvent m
 messageHandler state handler =
-  effectHandler state (\action state -> pure (handler action state))
+  effectHandler state (\event state -> pure (handler event state))
 
 {-|
 
@@ -180,21 +180,21 @@ a button:
 
 -}
 effectHandler
-  :: ( FromJSON action
+  :: ( FromJSON event
      , FromJSON state
-     , ToJSON action
-     , ToJSON parentAction
+     , ToJSON event
+     , ToJSON parentEvent
      , ToJSON state
      , Typeable state
      , Eq state
      )
   => state
   -- ^ initial state
-  -> (action -> state -> m (state -> state, [DirectedEvent parentAction action]))
+  -> (event -> state -> m (state -> state, [DirectedEvent parentEvent event]))
   -- ^ reducer (note the m!)
-  -> (state -> Purview action any1 m)
+  -> (state -> Purview event m)
   -- ^ continuation
-  -> Purview parentAction any2 m
+  -> Purview parentEvent m
 effectHandler state handler =
   Hide . EffectHandler Nothing Nothing state handler
 
@@ -205,11 +205,11 @@ to send an event up to it, and it will only be sent once.
 
 -}
 once
-  :: ToJSON action
-  => ((action -> Event) -> Event)
-  -> Purview parentAction action m
-  -> Purview parentAction action m
-once sendAction = Once sendAction False
+  :: ToJSON event
+  => ((event -> Event) -> Event)
+  -> Purview event m
+  -> Purview event m
+once sendEvent = Once sendEvent False
 
 {-
 
@@ -217,37 +217,37 @@ Helpers
 
 -}
 
-div :: [Purview parentAction action m] -> Purview parentAction action m
+div :: [Purview event m] -> Purview event m
 div = Html "div"
 
-span :: [Purview parentAction action m] -> Purview parentAction action m
+span :: [Purview event m] -> Purview event m
 span = Html "span"
 
-h1 :: [Purview parentAction action m] -> Purview parentAction action m
+h1 :: [Purview event m] -> Purview event m
 h1 = Html "h1"
 
-h2 :: [Purview parentAction action m] -> Purview parentAction action m
+h2 :: [Purview event m] -> Purview event m
 h2 = Html "h2"
 
-h3 :: [Purview parentAction action m] -> Purview parentAction action m
+h3 :: [Purview event m] -> Purview event m
 h3 = Html "h3"
 
-h4 :: [Purview parentAction action m] -> Purview parentAction action m
+h4 :: [Purview event m] -> Purview event m
 h4 = Html "h4"
 
-p :: [Purview parentAction action m] -> Purview parentAction action m
+p :: [Purview event m] -> Purview event m
 p = Html "p"
 
-button :: [Purview parentAction action m] -> Purview parentAction action m
+button :: [Purview event m] -> Purview event m
 button = Html "button"
 
-form :: [Purview parentAction action m] -> Purview parentAction action m
+form :: [Purview event m] -> Purview event m
 form = Html "form"
 
-input :: [Purview parentAction action m] -> Purview parentAction action m
+input :: [Purview event m] -> Purview event m
 input = Html "input"
 
-text :: String -> Purview parentAction action m
+text :: String -> Purview event m
 text = Text
 
 {-|
@@ -258,29 +258,29 @@ For adding styles
 > blueButton = blue $ button [ text "I'm blue" ]
 
 -}
-style :: String -> Purview parentAction action m -> Purview parentAction action m
+style :: String -> Purview event m -> Purview event m
 style = Attribute . Style
 
 {-|
 
-This will send the action to the handler above it whenever "click" is triggered
+This will send the event to the handler above it whenever "click" is triggered
 on the frontend.  It will be bound to whichever 'HTML' is beneath it.
 
 -}
-onClick :: ToJSON action => action -> Purview parentAction action m -> Purview parentAction action m
+onClick :: ToJSON event => event -> Purview event m -> Purview event m
 onClick = Attribute . On "click"
 
 {-|
 
-This will send the action to the handler above it whenever "submit" is triggered
+This will send the event to the handler above it whenever "submit" is triggered
 on the frontend.
 
 -}
-onSubmit :: ToJSON action => action -> Purview parentAction action m -> Purview parentAction action m
+onSubmit :: ToJSON event => event -> Purview event m -> Purview event m
 onSubmit = Attribute . On "submit"
 
-identifier :: String -> Purview parentAction action m -> Purview parentAction action m
+identifier :: String -> Purview event m -> Purview event m
 identifier = Attribute . Generic "id"
 
-classes :: [String] -> Purview parentAction action m -> Purview parentAction action m
+classes :: [String] -> Purview event m -> Purview event m
 classes xs = Attribute . Generic "class" $ unwords xs

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -10,7 +10,7 @@ import Unsafe.Coerce (unsafeCoerce)
 
 {-
 
-Since actions target specific locations, we can't stop going the tree early
+Since events target specific locations, we can't stop going the tree early
 because changes may have happened beneath the top level.  kind of the
 downside not having a single, passed down, state.
 
@@ -36,9 +36,9 @@ instance ToJSON a => ToJSON (Change a) where
 diff
   :: Maybe Location
   -> Location
-  -> Purview parentAction action m
-  -> Purview parentAction action m
-  -> [Change (Purview parentAction action m)]
+  -> Purview event m
+  -> Purview event m
+  -> [Change (Purview event m)]
 diff target location oldGraph newGraph = case (oldGraph, newGraph) of
 
   (Html kind children, Html kind' children') ->

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -55,7 +55,7 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
   (unknown, Html kind children) ->
     [Update location newGraph]
 
-  (Hide (EffectHandler _ loc state _ cont), Hide (EffectHandler _ loc' newState _ newCont)) ->
+  (EffectHandler _ loc state _ cont, EffectHandler _ loc' newState _ newCont) ->
     case cast state of
       Just state' ->
         [Update location newGraph | state' /= newState && loc == loc']
@@ -71,13 +71,13 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
       Nothing ->
         [Update location newGraph]
 
-  ((Attribute attr a), (Attribute attr' b)) ->
+  (Attribute attr a, Attribute attr' b) ->
     [Update location newGraph | attr /= attr']
 
-  ((Value _), _) ->
+  (Value _, _) ->
     [Update location newGraph]
 
-  ((EffectHandler _ _ _ _ _), _) ->
+  (EffectHandler _ _ _ _ _, _) ->
     [Update location newGraph]
 
   (_, _) -> [Update location newGraph]

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -47,7 +47,7 @@ spec = parallel $ do
 
       it "diffs handler children if the state is different" $ do
         let
-          handler1 :: (String -> Purview String action IO) -> Purview String action IO
+          handler1 :: (String -> Purview String IO) -> Purview String IO
           handler1 = messageHandler "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           handler2 = messageHandler "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
@@ -70,7 +70,7 @@ spec = parallel $ do
 
       it "diffs handler children if the state is different" $ do
         let
-          handler1 :: (String -> Purview String action IO) -> Purview String action IO
+          handler1 :: (String -> Purview String IO) -> Purview String IO
           handler1 = effectHandler "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           handler2 = effectHandler "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = div [ handler1 (const (text "the original")) ]
@@ -83,7 +83,7 @@ spec = parallel $ do
 
       it "continues going down the tree even if the state is the same at the top" $ do
         let
-          handler1 :: (String -> Purview String action IO) -> Purview String action IO
+          handler1 :: (String -> Purview String IO) -> Purview String IO
           handler1 = effectHandler "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           handler2 = effectHandler "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = fst . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -90,7 +90,7 @@ spec = parallel $ do
           newTree = fst . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 
         diff (Just [0, 0]) [] oldTree newTree `shouldBe`
-          [ Update [0, 0] (Hide $ EffectHandler
+          [ Update [0, 0] (EffectHandler
                             (Just [0])
                             (Just [0, 0])
                             "different state"

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -27,12 +27,6 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
       let children = fmap (applyNewState fromEvent) cont
       in EffectHandler ploc loc state handler children
 
-  Hide x ->
-    let
-      children = applyNewState fromEvent x
-    in
-      Hide children
-
   Html kind children ->
     Html kind $ fmap (applyNewState fromEvent) children
 
@@ -96,8 +90,6 @@ runEvent fromEvent@(Event { message, location }) component = case component of
     pure $ concat childEvents'
 
   Attribute n cont -> runEvent fromEvent cont
-
-  Hide x -> runEvent fromEvent x
 
   Once _ _ cont -> runEvent fromEvent cont
 

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -18,8 +18,8 @@ This is a special case event to assign new state to handlers
 -}
 applyNewState
   :: Event
-  -> Purview parentAction action m
-  -> Purview parentAction action m
+  -> Purview event m
+  -> Purview event m
 applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case component of
   EffectHandler ploc loc state handler cont -> case cast newStateFn of
     Just newStateFn' -> EffectHandler ploc loc (newStateFn' state) handler cont
@@ -48,7 +48,7 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
 applyNewState (Event {}) component = component
 
 
-runEvent :: Monad m => Event -> Purview parentAction action m -> m [Event]
+runEvent :: Monad m => Event -> Purview event m -> m [Event]
 runEvent (StateChangeEvent _ _) _ = pure []
 runEvent fromEvent@(Event { message, location }) component = case component of
   EffectHandler parentLocation loc state handler cont -> case fromJSON message of

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -39,7 +39,7 @@ in a non-forked fashioned.  If you try void . forkIO you end up back in m a -> I
 hell.
 
 -}
-apply :: MonadIO m => TChan Event -> Event -> Purview parentAction action m -> m (Purview parentAction action m)
+apply :: MonadIO m => TChan Event -> Event -> Purview event m -> m (Purview event m)
 apply eventBus newStateEvent@StateChangeEvent {} component =
   pure $ applyNewState newStateEvent component
 apply eventBus fromEvent@Event {event=eventKind} component =
@@ -60,7 +60,7 @@ spec = parallel $ do
         actionHandler "up" _ = 1
         actionHandler _    _ = 0
 
-        handler :: Purview () a IO
+        handler :: Purview () IO
         handler =
           simpleHandler (0 :: Int)
             actionHandler
@@ -91,7 +91,7 @@ spec = parallel $ do
         let event = Event { event="click", message="up", location=Nothing }
         chan <- newTChanIO
 
-        component <- apply chan event (x :: Purview String String IO)
+        component <- apply chan event (x :: Purview String IO)
         render component `shouldContain` "always present"
 
     it "works for setting state across many different trees" $
@@ -99,7 +99,7 @@ spec = parallel $ do
         let event = Event { event="newState", message="up", location=Just [] }
         chan <- newTChanIO
 
-        component <- apply chan event (x :: Purview String String IO)
+        component <- apply chan event (x :: Purview String IO)
         -- this tests 2 things
         -- 1. that it fully goes down the tree
         -- 2. the component remains the same, since the event doesn't

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -36,7 +36,7 @@ eventLoop
   -> Log IO
   -> TChan Event
   -> WebSockets.Connection
-  -> Purview parentAction action m
+  -> Purview event m
   -> IO ()
 eventLoop devMode runner log eventBus connection component = do
   message <- atomically $ readTChan eventBus

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -17,7 +17,7 @@ It also assigns a location to message and effect handlers.
 
 -}
 
-prepareTree :: Purview parentAction action m -> (Purview parentAction action m, [Event])
+prepareTree :: Purview event m -> (Purview event m, [Event])
 prepareTree = prepareTree' [] []
 
 type Location = [Int]
@@ -25,8 +25,8 @@ type Location = [Int]
 prepareTree'
   :: Location
   -> Location
-  -> Purview parentAction action m
-  -> (Purview parentAction action m, [Event])
+  -> Purview event m
+  -> (Purview event m, [Event])
 prepareTree' parentLocation location component = case component of
   Attribute attrs cont ->
     let result = prepareTree' parentLocation location cont

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -62,10 +62,6 @@ prepareTree' parentLocation location component = case component of
         in
           (Once effect True (fst rest), snd rest)
 
-  Hide x ->
-    let (child, actions) = prepareTree' parentLocation location x
-    in (Hide child, actions)
-
   Value x -> (Value x, [])
 
   Text x -> (Text x, [])

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -16,7 +16,7 @@ spec = parallel $ do
   describe "prepareTree" $ do
 
     it "works across a variety of trees" $ do
-      property $ \x -> show (fst (prepareTree (x :: Purview String String IO))) `shouldContain` "always present"
+      property $ \x -> show (fst (prepareTree (x :: Purview String IO))) `shouldContain` "always present"
 
     it "sets hasRun to True" $ do
       let

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -85,12 +85,12 @@ spec = parallel $ do
 
         component = timeHandler (const (Text ""))
 
-      component `shouldBe` Hide (EffectHandler Nothing Nothing Nothing handle (const (Text "")))
+      component `shouldBe` (EffectHandler Nothing Nothing Nothing handle (const (Text "")))
 
       let
         graphWithLocation = fst (prepareTree component)
 
-      graphWithLocation `shouldBe` Hide (EffectHandler (Just []) (Just []) Nothing handle (const (Text "")))
+      graphWithLocation `shouldBe` (EffectHandler (Just []) (Just []) Nothing handle (const (Text "")))
 
     it "assigns a different location to child handlers" $ do
       let
@@ -111,7 +111,7 @@ spec = parallel $ do
 
       show graphWithLocation
         `shouldBe`
-        "div [  Hide EffectHandler Just [] Just [0] \"null\" \"\" Hide EffectHandler Just [] Just [1] \"null\" \"\" ] "
+        "div [  EffectHandler Just [] Just [0] \"null\" \"\" EffectHandler Just [] Just [1] \"null\" \"\" ] "
 
     it "assigns a different location to nested handlers" $ do
       let
@@ -129,7 +129,7 @@ spec = parallel $ do
 
         graphWithLocation = fst (prepareTree component)
 
-      show graphWithLocation `shouldBe` "Hide EffectHandler Just [] Just [] \"null\" Hide EffectHandler Just [] Just [0] \"null\" \"\""
+      show graphWithLocation `shouldBe` "EffectHandler Just [] Just [] \"null\" EffectHandler Just [] Just [0] \"null\" \"\""
 
 
 main :: IO ()

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -5,13 +5,13 @@ import Prelude hiding (div)
 import Test.Hspec
 import Purview
 
-upButton :: Purview parentAction String m
+upButton :: Purview String m
 upButton = onClick ("up" :: String) $ div [ text "up" ]
 
-downButton :: Purview parentAction String m
+downButton :: Purview String m
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
-handler :: Applicative m => (Int -> Purview String action m) -> Purview String action m
+handler :: Applicative m => (Int -> Purview String m) -> Purview String m
 handler = simpleHandler 0 action
   where
     action :: String -> Int -> Int
@@ -25,7 +25,7 @@ counter state = div
   , downButton
   ]
 
-component :: Applicative m => Purview String String m
+component :: Applicative m => Purview String m
 component = handler counter
 
 event' :: String

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -46,10 +46,10 @@ they reach a real HTML tag.
 
 -}
 
-render :: Purview parentAction action m -> String
+render :: Purview action m -> String
 render = render' []
 
-render' :: [Attributes action] -> Purview parentAction action m -> String
+render' :: [Attributes action] -> Purview action m -> String
 render' attrs tree = case tree of
   Html kind rest ->
     "<" <> kind <> renderAttributes attrs <> ">"

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -70,5 +70,3 @@ render' attrs tree = case tree of
     render' attrs cont
 
   Value a -> show a
-
-  Hide a -> render' attrs (unsafeCoerce a)

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -23,7 +23,7 @@ spec = parallel $ do
   describe "render" $ do
 
     it "can render an assortment of different trees" $
-      property $ \x -> render (x :: Purview String String IO) `shouldContain` "always present"
+      property $ \x -> render (x :: Purview String IO) `shouldContain` "always present"
 
     it "can create a div" $ do
       let element = Html "div" [Text "hello world"]

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -17,7 +17,7 @@ nicely.
 
 -}
 
-testHandler :: (String -> Purview String action IO) -> Purview String action IO
+testHandler :: (String -> Purview String IO) -> Purview String IO
 testHandler = effectHandler ("" :: String) reducer
   where
     reducer :: String -> String -> IO (String -> String, [DirectedEvent String String])
@@ -25,7 +25,7 @@ testHandler = effectHandler ("" :: String) reducer
 
 testOnce = once (\send -> send "")
 
-sizedArbExpr :: Int -> Gen (Purview String String IO)
+sizedArbExpr :: Int -> Gen (Purview String IO)
 sizedArbExpr 0 = do pure $ text "always present"
 sizedArbExpr n = do
   es <- vectorOf 2 (sizedArbExpr (n-1))
@@ -36,5 +36,5 @@ sizedArbExpr n = do
     , testOnce (div es)
     ]
 
-instance Arbitrary (Purview String String IO) where
+instance Arbitrary (Purview String IO) where
   arbitrary = resize 3 $ sized sizedArbExpr

--- a/src/experiments/Experiment21.hs
+++ b/src/experiments/Experiment21.hs
@@ -29,13 +29,13 @@ Senders (triggered by events in the HTML) can only send events to the
 handler above them in the graph.
 
 There will be few handlers / senders, and a lot of Html. Having the
-parentEvent on Senders and Html doesn't fit the model, since it's
+event on Senders and Html doesn't fit the model, since it's
 not needed.  Is there a better way to model this that would remove
-parentEvent, but still keep track of it?  New Handlers can be anywhere
+event, but still keep track of it?  New Handlers can be anywhere
 in the tree and need to know what events it can send to the parent.
 
 If there was some way for the Handler to "know" that the "action" type
-of the Sender / Html it's embedded in was its "parentEvent" type, that'd
+of the Sender / Html it's embedded in was its "event" type, that'd
 be pretty cool but might not be possible?
 
 I've been wondering if this could be solved with implicit params or
@@ -45,60 +45,57 @@ something monadic, but I'm not sure.
 
 data Event a b = Parent a | Self b
 
-data Graph parentEvent event where
+type Reducer event newEvent = Graph event
+
+data Graph event where
   Sender
     :: event
-    -> [Graph parentEvent event]
+    -> [Graph event]
     -- ^ children
-    -> Graph parentEvent event
+    -> Graph event
   Handler ::
-    { handler :: newEvent -> [Event parentEvent newEvent]
+    { handler :: newEvent -> [Event event newEvent]
     -- ^ receives the sender event and generates new events
-    , children :: [Graph newEvent any]
+    , children :: [Graph newEvent]
     }
-    -> Graph parentEvent newEvent
+    -> Reducer event newEvent
   Html
     :: String
-    -> [Graph parentEvent event]
+    -> [Graph event]
     -- ^ children
-    -> Graph parentEvent event
+    -> Graph event
 
 data Vertical = North | South
 data Horizontal = East | West
 
-data RegistrationFormEvent = UserInfoSubmitted { email :: Maybe String, username :: Maybe String }
+-- here you can see where having the event type makes less sense
+-- westSender :: Graph event
+westSender = Sender East [ Html "button" [] ]
 
-registrationForm = Sender UserInfoSubmitted
-  [ Html "form"
-      [ -- email input
-        -- username input
-        -- submit button
-      ]
-  ]
-
-registrationHandler = Handler handle
-  where handle UserInfoSubmitted { name, username } = do
-          -- check the name is valid
-          -- check the username is valid
-          --
-
--- here you can see where having the parentEvent type makes less sense
-westSender :: Graph parentEvent Horizontal
-westSender = Sender West [ Html "button" [] ]
-
-child :: Graph Vertical Horizontal
+-- child :: Graph Vertical
 child = Handler (\event -> [ Parent North, Self East ]) [ westSender ]
 
-parent :: [Graph Vertical any] -> Graph () Vertical
 parent = Handler (\event -> [ Self North ])
 
-graph :: Graph () Vertical
 graph = parent [ child ]
 
--- I see I can do something like this:
-type Sender event = forall parentEvent. Graph parentEvent event
+data Temp where
+  Temp :: { value :: a, value2 :: a } -> Temp
 
--- to hide having to type out the parentEvent, but it's still not
--- exactly matching with how it really works
-eastSender :: Sender Horizontal
-eastSender = Sender East []
+test = Temp () ""
+
+{- Checks
+
+- handler / handler mismatch
+- sender / handler mismatch
+
+-}
+
+
+-- -- I see I can do something like this:
+-- type Sender event = forall event. Graph event event
+--
+-- -- to hide having to type out the event, but it's still not
+-- -- exactly matching with how it really works
+-- eastSender :: Sender Horizontal
+-- eastSender = Sender East []

--- a/src/experiments/Experiment21.hs
+++ b/src/experiments/Experiment21.hs
@@ -79,10 +79,17 @@ parent = Handler (\event -> [ Self North ])
 
 graph = parent [ child ]
 
-data Temp where
-  Temp :: { value :: a, value2 :: a } -> Temp
+-- data Temp where
+--   Temp :: { value :: a, value2 :: a } -> Temp
 
-test = Temp () ""
+-- test = Temp () ""
+
+type Temp simonSays a = Maybe a
+
+a = Just 1 :: Temp Integer Integer
+b = Nothing :: Temp String String
+
+c = [a, b]
 
 {- Checks
 


### PR DESCRIPTION
This is great, finally the AST reflects much closer to how it actually works.  No more worry about specifying an odd `parentAction` in parts that really don't care about it.

I also changed the name from `action` to `event`, since that's closer to what it is and what's widely understood.  Event loops take in events, eh?