### PR TITLE
Remove messageHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $(deriveJSON defaultOptions ''Direction)
 upButton = onClick Up $ div [ text "up" ]
 downButton = onClick Down $ div [ text "down" ]
 
-handler = messageHandler (0 :: Int) reducer
+countHandler = handler (0 :: Int) reducer
   where
     reducer Up   state = (const $ state + 1, [])
     reducer Down state = (const $ state - 1, [])
@@ -42,7 +42,7 @@ counter state = div
   , downButton
   ]
 
-view = handler counter
+view = countHandler counter
 
 main = Purview.run defaultConfiguration { component=view }
 ```
@@ -100,12 +100,11 @@ Now `render view` will produce `<button>click</button>`.  Like all the built in 
 
 ### Events
 
-At the core of Purview are three event handlers, in order of increasing power:
-1. `simpleHandler`: Used for just returning a new state.  No messages or effects.
-2. `messageHandler`: Used when you need to send messages to the component itself or to its parent.
-3. `effectHandler`: Used when you need the above and access to IO / your monad stack / algebraic effects.
+At the core of Purview are event handlers:
+1. `handler`: Used for just returning a new state.  No messages or effects.
+2. `effectHandler`: Used when you need the above and access to IO / your monad stack / algebraic effects.
 
-The first two are just some sugar around `effectHandler`.
+The first one is just some sugar around `effectHandler`.
 
 Handlers take an initial state and a reducer.  The reducer receives actions from anywhere below them in the tree, and returns the new state with a list of actions to send either to itself or up the tree to the parent.  The handler passes down the state to its child.  This is the core idea to make it all interactive.
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -105,13 +105,13 @@ For example, let's say you want to make a button that switches between saying
 
 > view direction = onClick "toggle" $ button [ text direction ]
 >
-> handler = simpleHandler "up" reduce
+> handler = handler "up" reduce
 >   where reduce "toggle" state = if state == "up" then "down" else "up"
 >
 > component = handler view
 
 -}
-simpleHandler
+handler
   :: ( FromJSON event
      , FromJSON state
      , ToJSON event
@@ -123,40 +123,12 @@ simpleHandler
      )
   => state
   -- ^ The initial state
-  -> (event -> state -> state)
+  -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))
   -- ^ The reducer, or how the state should change for an event
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
-simpleHandler state handler =
-  effectHandler state (\event state -> pure (const $ handler event state, []))
-
-{-|
-
-More powerful than the 'simpleHandler', it can send messages to itself or its
-parent.  You will also note that instead of just returning the new state, it
-returns a function to transform the state.  This is because handlers run in
-their own threads.
-
--}
-messageHandler
-  :: ( FromJSON event
-     , FromJSON state
-     , ToJSON event
-     , ToJSON parentEvent
-     , ToJSON state
-     , Typeable state
-     , Eq state
-     , Applicative m
-     )
-  => state
-  -- ^ initial state
-  -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))
-  -- ^ reducer
-  -> (state -> Purview event m)
-  -- ^ continuation
-  -> Purview parentEvent m
-messageHandler state handler =
+handler state handler =
   effectHandler state (\event state -> pure (handler event state))
 
 {-|

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -36,20 +36,12 @@ spec = parallel $ do
       diff Nothing [] oldTree newTree `shouldBe` [Update [0] (div [ text "morning" ])]
 
     describe "message handlers" $ do
---      it "doesn't diff handler children if the state is the same" $ do
---        let
---          mkHandler :: (String -> Purview String action IO) -> Purview String action IO
---          mkHandler = messageHandler "initial state" (\action state -> (state <> action, [] :: [DefaultAction]))
---          oldTree = div [ mkHandler (const (text "the original")) ]
---          newTree = div [ mkHandler (const (text "this is different")) ]
---
---        diff [] oldTree newTree `shouldBe` []
 
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = messageHandler "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
-          handler2 = messageHandler "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler1 = handler "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler2 = handler "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -59,14 +51,6 @@ spec = parallel $ do
           ]
 
     describe "effect handlers" $ do
---      it "doesn't diff handler children if the state is the same" $ do
---        let
---          mkHandler :: (String -> Purview String action IO) -> Purview String action IO
---          mkHandler = effectHandler "initial state" (\action state -> pure $ (state <> action, ([] :: [DirectedEvent String String])))
---          oldTree = div [ mkHandler (const (text "the original")) ]
---          newTree = div [ mkHandler (const (text "this is different")) ]
---
---        diff [] oldTree newTree `shouldBe` []
 
       it "diffs handler children if the state is different" $ do
         let

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -68,8 +68,7 @@ module Purview
   -- | These are how you can catch events sent from things like 'onClick' and
   -- change state, or in the case of 'effectHandler', make API requests or call
   -- functions from your project.
-  , simpleHandler
-  , messageHandler
+  , handler
   , effectHandler
 
   -- ** HTML helpers

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -11,12 +11,12 @@ upButton = onClick ("up" :: String) $ div [ text "up" ]
 downButton :: Purview String m
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
-handler :: Applicative m => (Int -> Purview String m) -> Purview String m
-handler = simpleHandler 0 action
+reducer :: Applicative m => (Int -> Purview String m) -> Purview String m
+reducer = handler 0 action
   where
-    action :: String -> Int -> Int
-    action "up" _ = 1
-    action _    _ = 0
+    action :: String -> Int -> (Int -> Int, [DirectedEvent String String])
+    action "up" _ = (const 1, [])
+    action _    _ = (const 0, [])
 
 -- counter :: Show a => a -> Purview parentAction action m
 counter state = div
@@ -26,7 +26,7 @@ counter state = div
   ]
 
 component :: Applicative m => Purview String m
-component = handler counter
+component = reducer counter
 
 event' :: String
 event' = "{\"event\":\"click\",\"message\":\"up\"}"


### PR DESCRIPTION
I'm thinking this is a little cleaner as the most important distinction is effects vs no effects

I might change it so that the default handlers don't expect messages and provider `handler' / effectHandler'` for when you need messages.  That'd clean up examples, but then I wonder: should the default's just `const` whatever is returned?  Hmm.