### PR TITLE
Remove ToJSON/FromJSON constraints

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,9 +46,9 @@ dependencies:
 - blaze-builder                 >= 0.4.2 && < 0.5
 - http-types                    >= 0.12.3 && < 0.13
 
-- hspec #
-- QuickCheck #
-- time
+# - hspec #
+# - QuickCheck #
+# - time #
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -46,8 +46,9 @@ dependencies:
 - blaze-builder                 >= 0.4.2 && < 0.5
 - http-types                    >= 0.12.3 && < 0.13
 
-# - hspec #
-# - QuickCheck #
+- hspec #
+- QuickCheck #
+- time
 
 library:
   source-dirs: src

--- a/purview.cabal
+++ b/purview.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -56,17 +56,14 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      QuickCheck
-    , aeson >=2.0.3 && <2.1
+      aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
-    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
-    , time
     , websockets >=0.12.7 && <0.13
   default-language: Haskell2010
 
@@ -121,19 +118,16 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      QuickCheck
-    , aeson >=2.0.3 && <2.1
+      aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
     , criterion >=1.5.13 && <1.6
-    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
-    , time
     , websockets >=0.12.7 && <0.13
   buildable: False
   default-language: Haskell2010

--- a/purview.cabal
+++ b/purview.cabal
@@ -56,14 +56,17 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      aeson >=2.0.3 && <2.1
+      QuickCheck
+    , aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
+    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
+    , time
     , websockets >=0.12.7 && <0.13
   default-language: Haskell2010
 
@@ -118,16 +121,19 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      aeson >=2.0.3 && <2.1
+      QuickCheck
+    , aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
     , criterion >=1.5.13 && <1.6
+    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
+    , time
     , websockets >=0.12.7 && <0.13
   buildable: False
   default-language: Haskell2010

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -28,11 +29,16 @@ instance Eq (Attributes event) where
   (Style _) == _ = False
 
   (On kind ident event) == (On kind' ident' event') =
-    kind == kind' && event == event'
+    kind == kind' && event == event' && ident == ident'
   (On _ _ _) == _ = False
 
   (Generic name value) == (Generic name' value') = name == name' && value == value'
   (Generic _ _) == _ = False
+
+instance Show (Attributes event) where
+  show (On kind ident evt) = "On " <> show kind <> " " <> show ident
+  show (Style str) = "Style " <> show str
+  show (Generic attrKey attrValue) = "Generic " <> show attrKey <> show attrValue
 
 type Identifier = Maybe [Int]
 type ParentIdentifier = Identifier
@@ -86,7 +92,7 @@ instance Show (Purview event m) where
     <> show (encode state) <> " "
     <> show (cont state)
   show (Once _ hasRun cont) = "Once " <> show hasRun <> " " <> show cont
-  show (Attribute _attrs cont) = "Attr " <> show cont
+  show (Attribute attrs cont) = "Attr " <> show attrs <> " " <> show cont
   show (Text str) = show str
   show (Html kind children) =
     kind <> " [ " <> concatMap ((<>) " " . show) children <> " ] "

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -16,7 +16,7 @@ are applied during rendering.
 
 -}
 data Attributes event where
-  On :: ToJSON event => String -> event -> Attributes event
+  On :: Eq event => String -> Identifier -> event -> Attributes event
   -- ^ part of creating handlers for different events, e.g. On "click"
   Style :: String -> Attributes event
   -- ^ inline css
@@ -27,8 +27,9 @@ instance Eq (Attributes event) where
   (Style a) == (Style b) = a == b
   (Style _) == _ = False
 
-  (On kind event) == (On kind' event') = kind == kind' && encode event == encode event'
-  (On _ _) == _ = False
+  (On kind ident event) == (On kind' ident' event') =
+    kind == kind' && event == event'
+  (On _ _ _) == _ = False
 
   (Generic name value) == (Generic name' value') = name == name' && value == value'
   (Generic _ _) == _ = False
@@ -233,8 +234,8 @@ This will send the event to the handler above it whenever "click" is triggered
 on the frontend.  It will be bound to whichever 'HTML' is beneath it.
 
 -}
-onClick :: ToJSON event => event -> Purview event m -> Purview event m
-onClick = Attribute . On "click"
+onClick :: Eq event => event -> Purview event m -> Purview event m
+onClick = Attribute . On "click" Nothing
 
 {-|
 
@@ -242,8 +243,8 @@ This will send the event to the handler above it whenever "submit" is triggered
 on the frontend.
 
 -}
-onSubmit :: ToJSON event => event -> Purview event m -> Purview event m
-onSubmit = Attribute . On "submit"
+onSubmit :: Eq event => event -> Purview event m -> Purview event m
+onSubmit = Attribute . On "submit" Nothing
 
 identifier :: String -> Purview event m -> Purview event m
 identifier = Attribute . Generic "id"

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -58,12 +58,8 @@ data Purview event m where
 
   -- | All the handlers boil down to this one.
   EffectHandler
-    :: ( FromJSON newEvent
-       , ToJSON newEvent
-       , FromJSON state
-       , ToJSON state
-       , Typeable state
-       , Typeable newEvent
+    :: ( Typeable newEvent
+       , Show state
        , Eq state
        )
     => ParentIdentifier
@@ -90,7 +86,7 @@ instance Show (Purview event m) where
     "EffectHandler "
     <> show parentLocation <> " "
     <> show location <> " "
-    <> show (encode state) <> " "
+    <> show state <> " "
     <> show (cont state)
   show (Once _ hasRun cont) = "Once " <> show hasRun <> " " <> show cont
   show (Attribute attrs cont) = "Attr " <> show attrs <> " " <> show cont
@@ -119,12 +115,8 @@ For example, let's say you want to make a button that switches between saying
 
 -}
 handler
-  :: ( FromJSON event
-     , FromJSON state
-     , ToJSON event
-     , ToJSON state
-     , Typeable state
-     , Typeable event
+  :: ( Typeable event
+     , Show state
      , Eq state
      , Applicative m
      )
@@ -156,12 +148,8 @@ a button:
 
 -}
 effectHandler
-  :: ( FromJSON event
-     , FromJSON state
-     , ToJSON event
-     , ToJSON state
-     , Typeable state
-     , Typeable event
+  :: ( Typeable event
+     , Show state
      , Eq state
      )
   => state

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -17,7 +17,7 @@ are applied during rendering.
 
 -}
 data Attributes event where
-  On :: Eq event => String -> Identifier -> event -> Attributes event
+  On :: (Eq event, Typeable event, Show event) => String -> Identifier -> event -> Attributes event
   -- ^ part of creating handlers for different events, e.g. On "click"
   Style :: String -> Attributes event
   -- ^ inline css
@@ -63,6 +63,7 @@ data Purview event m where
        , FromJSON state
        , ToJSON state
        , Typeable state
+       , Typeable newEvent
        , Eq state
        )
     => ParentIdentifier
@@ -123,6 +124,7 @@ handler
      , ToJSON event
      , ToJSON state
      , Typeable state
+     , Typeable event
      , Eq state
      , Applicative m
      )
@@ -159,6 +161,7 @@ effectHandler
      , ToJSON event
      , ToJSON state
      , Typeable state
+     , Typeable event
      , Eq state
      )
   => state
@@ -240,7 +243,7 @@ This will send the event to the handler above it whenever "click" is triggered
 on the frontend.  It will be bound to whichever 'HTML' is beneath it.
 
 -}
-onClick :: Eq event => event -> Purview event m -> Purview event m
+onClick :: (Typeable event, Eq event, Show event) => event -> Purview event m -> Purview event m
 onClick = Attribute . On "click" Nothing
 
 {-|
@@ -249,7 +252,7 @@ This will send the event to the handler above it whenever "submit" is triggered
 on the frontend.
 
 -}
-onSubmit :: Eq event => event -> Purview event m -> Purview event m
+onSubmit :: (Typeable event, Eq event, Show event) => event -> Purview event m -> Purview event m
 onSubmit = Attribute . On "submit" Nothing
 
 identifier :: String -> Purview event m -> Purview event m

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -59,6 +59,7 @@ data Purview event m where
   -- | All the handlers boil down to this one.
   EffectHandler
     :: ( Typeable newEvent
+       , Typeable state
        , Show state
        , Eq state
        )
@@ -118,6 +119,7 @@ handler
   :: ( Typeable event
      , Show state
      , Eq state
+     , Typeable state
      , Applicative m
      )
   => state
@@ -151,6 +153,7 @@ effectHandler
   :: ( Typeable event
      , Show state
      , Eq state
+     , Typeable state
      )
   => state
   -- ^ initial state

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -55,6 +55,7 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
   (unknown, Html kind children) ->
     [Update location newGraph]
 
+  -- TODO: add Handler
   (EffectHandler _ loc state _ cont, EffectHandler _ loc' newState _ newCont) ->
     case cast state of
       Just state' ->

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -46,9 +46,7 @@ spec = parallel $ do
           newTree = div [ handler2 (const (text "this is different")) ]
 
         diff Nothing [] oldTree newTree `shouldBe`
-          [ Update [0] (handler2 (const (text "this is different")))
-          , Update [0, 0] (text "this is different")
-          ]
+          [ Update [0] (handler2 (const (text "this is different"))) ]
 
     describe "effect handlers" $ do
 

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -122,18 +122,18 @@ findEvent event@Event { message=childLocation, location=handlerLocation } tree =
 --       -- locations match (cuts down on noise)
 --       let newStateEvent = [StateChangeEvent newStateFn loc | loc == location]
 --
--- --      let createMessage directedEvent = case directedEvent of
--- --            (Parent event) -> Event
--- --              -- TODO: this should probably be a new kind of event
--- --              { event = "internal"
--- --              , message = toJSON event
--- --              , location = parentLocation
--- --              }
--- --            (Self event) -> Event
--- --              { event = "internal"
--- --              , message = toJSON event
--- --              , location = loc
--- --              }
+--       let createMessage directedEvent = case directedEvent of
+--             (Parent event) -> Event
+--               -- TODO: this should probably be a new kind of event
+--               { event = "internal"
+--               , message = toJSON event
+--               , location = parentLocation
+--               }
+--             (Self event) -> Event
+--               { event = "internal"
+--               , message = toJSON event
+--               , location = loc
+--               }
 --
 --       -- here we handle sending events returned to either this
 --       -- same handler or passing it up the chain

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -93,6 +93,7 @@ findEvent event@Event { message=childLocation, location=handlerLocation } tree =
 
   Value _ -> Nothing
 
+-- TODO: continue down the tree
 runEvent :: Monad m => AnyEvent -> Purview event m -> m [Event]
 runEvent anyEvent@AnyEvent { event, handlerId } tree = case tree of
   Attribute attr cont ->

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE DuplicateRecordFields #-}
@@ -6,10 +7,12 @@ module EventHandling where
 import           Control.Concurrent.STM.TChan
 import           Data.Aeson
 import           Data.Typeable
+import           Data.Maybe
 
 import           Events
 import           Component
 
+import Debug.Trace
 
 {-|
 
@@ -42,57 +45,119 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
 applyNewState (Event {}) component = component
 
 
-runEvent :: Monad m => Event -> Purview event m -> m [Event]
-runEvent (StateChangeEvent _ _) _ = pure []
-runEvent fromEvent@(Event { message, location }) component = case component of
-  EffectHandler parentLocation loc state handler cont -> case fromJSON message of
-    Success parsedAction -> do
-      -- if locations match, we actually run what is in the handler
-      (newStateFn, events) <-
-        if loc == location
-        then handler parsedAction state
-        else pure (const state, [])
+data AnyEvent where
+  AnyEvent :: (Show evt, Typeable evt, Eq evt) => evt -> AnyEvent
 
-      -- although it doesn't break anything, only send this when the
-      -- locations match (cuts down on noise)
-      let newStateEvent = [StateChangeEvent newStateFn loc | loc == location]
+instance Show AnyEvent where
+  show (AnyEvent evt) = show evt
 
-      let createMessage directedEvent = case directedEvent of
-            (Parent event) -> Event
-              -- TODO: this should probably be a new kind of event
-              { event = "internal"
-              , message = toJSON event
-              , location = parentLocation
-              }
-            (Self event) -> Event
-              { event = "internal"
-              , message = toJSON event
-              , location = loc
-              }
+instance Eq AnyEvent where
+  (AnyEvent evt) == (AnyEvent evt') = case cast evt' of
+    Just evt'' -> evt == evt''
+    Nothing    -> False
 
-      -- here we handle sending events returned to either this
-      -- same handler or passing it up the chain
-      -- mapM_ (atomically . writeTChan eventBus . createMessage) events
-      let handlerEvents = fmap createMessage events
+findEvent :: Event -> Purview event m -> Maybe AnyEvent
 
-      -- ok, right, no where in this function does the tree actually change
-      -- that's handled by the setting state event
-      childEvents <- runEvent fromEvent (cont state)
+findEvent event@Event { message=childLocation, location=handlerLocation } tree = case tree of
+  Attribute attr cont -> case attr of
+    On _ ident evt ->
+      if ident == childLocation
+      then Just $ AnyEvent evt
+      else Nothing
+    _ -> findEvent event cont
 
-      -- so we can ignore the results from applyEvent and continue
-      -- pure $ EffectHandler parentLocation loc state handler cont
-      pure $ newStateEvent <> handlerEvents <> childEvents
+  Html _ children ->
+    case mapMaybe (findEvent event) children of
+      [found] -> Just found
+      [] -> Nothing
 
-    Error _err -> runEvent fromEvent (cont state)
+  EffectHandler _ ident state _ cont ->
+    findEvent event (cont state)
 
-  Html kind children -> do
-    childEvents' <- mapM (runEvent fromEvent) children
-    pure $ concat childEvents'
+  Text _ -> Nothing
 
-  Attribute n cont -> runEvent fromEvent cont
+  Value _ -> Nothing
 
-  Once _ _ cont -> runEvent fromEvent cont
+{- right, can't do this because my brain isn't big enough -}
+-- findInTree ::(Purview event m -> Bool) -> Purview event m -> Maybe (Purview event m)
+-- findInTree test tree = case tree of
+--   Attribute attr cont ->
+--     if test tree
+--     then Just tree
+--     else findInTree test cont
+--
+--   Html _ children ->
+--     if test tree
+--     then Just tree
+--     else case mapMaybe (findInTree test) children of
+--       [found] -> Just found
+--       []      -> Nothing
+--
+--   EffectHandler _ ident _ _ cont ->
+--     let found = fmap (\cont' -> findInTree test cont') cont
+--     in undefined
+--
+--   Text _ -> Nothing
+--
+--   Value _ -> Nothing
+--
+-- findParent :: Identifier -> Purview event m -> Purview event m
+-- findParent ident tree = undefined
+--
+-- findChild :: Identifier -> Purview event m -> Maybe event
+-- findChild = undefined
 
-  Text _ -> pure []
-
-  Value _ -> pure []
+-- runEvent :: Monad m => Event -> Purview event m -> m [Event]
+-- runEvent (StateChangeEvent _ _) _ = pure []
+-- runEvent fromEvent@(Event { message, location }) component = case component of
+--   EffectHandler parentLocation loc state handler cont -> case fromJSON message of
+--     Success parsedAction -> do
+--       -- if locations match, we actually run what is in the handler
+--       (newStateFn, events) <-
+--         if loc == location
+--         then handler parsedAction state
+--         else pure (const state, [])
+--
+--       -- although it doesn't break anything, only send this when the
+--       -- locations match (cuts down on noise)
+--       let newStateEvent = [StateChangeEvent newStateFn loc | loc == location]
+--
+-- --      let createMessage directedEvent = case directedEvent of
+-- --            (Parent event) -> Event
+-- --              -- TODO: this should probably be a new kind of event
+-- --              { event = "internal"
+-- --              , message = toJSON event
+-- --              , location = parentLocation
+-- --              }
+-- --            (Self event) -> Event
+-- --              { event = "internal"
+-- --              , message = toJSON event
+-- --              , location = loc
+-- --              }
+--
+--       -- here we handle sending events returned to either this
+--       -- same handler or passing it up the chain
+--       -- mapM_ (atomically . writeTChan eventBus . createMessage) events
+--       let handlerEvents = fmap createMessage events
+--
+--       -- ok, right, no where in this function does the tree actually change
+--       -- that's handled by the setting state event
+--       childEvents <- runEvent fromEvent (cont state)
+--
+--       -- so we can ignore the results from applyEvent and continue
+--       -- pure $ EffectHandler parentLocation loc state handler cont
+--       pure $ newStateEvent <> handlerEvents <> childEvents
+--
+--     Error _err -> runEvent fromEvent (cont state)
+--
+--   Html kind children -> do
+--     childEvents' <- mapM (runEvent fromEvent) children
+--     pure $ concat childEvents'
+--
+--   Attribute n cont -> runEvent fromEvent cont
+--
+--   Once _ _ cont -> runEvent fromEvent cont
+--
+--   Text _ -> pure []
+--
+--   Value _ -> pure []

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -39,251 +39,270 @@ in a non-forked fashioned.  If you try void . forkIO you end up back in m a -> I
 hell.
 
 -}
-apply :: MonadIO m => TChan Event -> Event -> Purview event m -> m (Purview event m)
-apply eventBus newStateEvent@StateChangeEvent {} component =
-  pure $ applyNewState newStateEvent component
-apply eventBus fromEvent@Event {event=eventKind} component =
-  case eventKind of
-    "newState" -> pure $ applyNewState fromEvent component
-    _          -> do
-      events <- runEvent fromEvent component
-      liftIO $ mapM_ (atomically . writeTChan eventBus) events
-      pure component
+-- apply :: MonadIO m => TChan Event -> Event -> Purview event m -> m (Purview event m)
+-- apply eventBus newStateEvent@StateChangeEvent {} component =
+--   pure $ applyNewState newStateEvent component
+-- apply eventBus fromEvent@Event {event=eventKind} component =
+--   case eventKind of
+--     "newState" -> pure $ applyNewState fromEvent component
+--     _          -> do
+--       events <- runEvent fromEvent component
+--       liftIO $ mapM_ (atomically . writeTChan eventBus) events
+--       pure component
 
 spec :: SpecWith ()
 spec = parallel $ do
-  describe "apply" $ do
+--  describe "apply" $ do
+--
+--    it "changes state" $ do
+--      let
+--        actionHandler :: String -> Int -> (Int -> Int, [DirectedEvent () String])
+--        actionHandler "up" _ = (const 1, [])
+--        actionHandler _    _ = (const 0, [])
+--
+--        reducer :: Purview () IO
+--        reducer =
+--          handler (0 :: Int)
+--            actionHandler
+--            (Text . show)
+--
+--      render reducer
+--        `shouldBe`
+--        "<div handler=\"null\">0</div>"
+--
+--      chan <- newTChanIO
+--
+--      let event' = Event { event="click", message="up", location=Nothing }
+--
+--      appliedHandler <- apply chan event' reducer
+--
+--      stateEvent <- atomically $ readTChan chan
+--
+--      show stateEvent `shouldBe` show (StateChangeEvent (id :: Int -> Int) Nothing)
+--
+--      afterState <- apply chan stateEvent appliedHandler
+--
+--      render afterState
+--        `shouldBe`
+--        "<div handler=\"null\">1</div>"
+--
+--    it "works for clicks across many different trees" $
+--      property $ \x -> do
+--        let event = Event { event="click", message="up", location=Nothing }
+--        chan <- newTChanIO
+--
+--        component <- apply chan event (x :: Purview String IO)
+--        render component `shouldContain` "always present"
+--
+--    it "works for setting state across many different trees" $
+--      property $ \x -> do
+--        let event = Event { event="newState", message="up", location=Just [] }
+--        chan <- newTChanIO
+--
+--        component <- apply chan event (x :: Purview String IO)
+--        -- this tests 2 things
+--        -- 1. that it fully goes down the tree
+--        -- 2. the component remains the same, since the event doesn't
+--        --    have a location that matches anything
+--        component `shouldBe` x
+--
+--    it "works with typed messages" $ do
+--      let
+--        actionHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
+--        actionHandler Up   _ = (const 1, [])
+--        actionHandler Down _ = (const 0, [])
+--
+--        reducer =
+--          handler (0 :: Int)
+--            actionHandler
+--            (Text . show)
+--
+--      render reducer
+--        `shouldBe`
+--        "<div handler=\"null\">0</div>"
+--
+--      chan <- newTChanIO
+--
+--      let event' = Event { event="click", message=toJSON Up, location=Nothing }
+--
+--      appliedHandler <- apply chan event' reducer
+--
+--      stateEvent <- atomically $ readTChan chan
+--
+--      afterState <- apply chan stateEvent appliedHandler
+--
+--      render afterState
+--        `shouldBe`
+--        "<div handler=\"null\">1</div>"
+--
+--    it "works after sending an event that did not match anything" $ do
+--      let
+--        actionHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
+--        actionHandler Up   _ = (const 1, [])
+--        actionHandler Down _ = (const 0, [])
+--
+--        reducer =
+--          handler (0 :: Int)
+--            actionHandler
+--            (Text . show)
+--
+--      chan <- newTChanIO
+--
+--      let event0 = Event { event="init", message="init", location=Nothing }
+--
+--      appliedHandler0 <- apply chan event0 reducer
+--      render appliedHandler0
+--        `shouldBe`
+--        "<div handler=\"null\">0</div>"
+--
+--      let event1 = Event { event="init", message=toJSON Up, location=Nothing }
+--
+--      appliedHandler1 <- apply chan event1 appliedHandler0
+--
+--      stateEvent <- atomically $ readTChan chan
+--      appliedHandler2 <- apply chan stateEvent appliedHandler1
+--
+--      render appliedHandler2
+--        `shouldBe`
+--        "<div handler=\"null\">1</div>"
+--
+--    it "works with a nested attribute" $ do
+--      let
+--        childHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
+--        childHandler Up   _ = (const 1, [Parent "hello"])
+--        childHandler Down _ = (const 0, [])
+--
+--        parentHandler :: String -> String -> (Id String, [DirectedEvent String String])
+--        parentHandler "hello" _ = (const "bye", [])
+--        parentHandler "bye" _ = (const "hello", [])
+--        parentHandler str _ = (const str, [])
+--
+--        styledContainer = style "font-size: 10px;" . div
+--
+--        reducer =
+--          handler ("" :: String) parentHandler
+--            $ \message ->
+--                styledContainer
+--                [ text message
+--                , handler (0 :: Int)
+--                    childHandler
+--                    (text . show)
+--                ]
+--
+--        component = reducer
+--
+--      chan <- newTChanIO
+--
+--      let
+--        locatedGraph = fst $ prepareTree component
+--        event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
+--
+--      afterEvent1 <- apply chan event1 locatedGraph
+--
+--      receivedEvent1 <- atomically $ readTChan chan
+--      show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
+--
+--      receivedEvent2 <- atomically $ readTChan chan
+--      receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
+--
+--    describe "sending events" $ do
+--
+--      it "can send an event to a parent" $ do
+--        let
+--          childHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
+--          childHandler Up   _ = (const 1, [Parent "hello"])
+--          childHandler Down _ = (const 0, [])
+--
+--          parentHandler :: String -> String -> (Id String, [DirectedEvent String String])
+--          parentHandler "hello" _ = (const "bye", [])
+--          parentHandler "bye" _ = (const "hello", [])
+--          parentHandler str _ = (const str, [])
+--
+--          reducer =
+--            handler ("" :: String) parentHandler
+--              $ \message ->
+--                  div
+--                  [ text message
+--                  , handler (0 :: Int)
+--                      childHandler
+--                      (text . show)
+--                  ]
+--
+--        chan <- newTChanIO
+--
+--        let locatedGraph = fst $ prepareTree reducer
+--
+--        render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
+--
+--        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
+--
+--        afterEvent1 <- apply chan event1 locatedGraph
+--
+--        receivedEvent1 <- atomically $ readTChan chan
+--        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
+--
+--        receivedEvent2 <- atomically $ readTChan chan
+--        -- correctly targeted to the parent
+--        receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
+--
+--
+--      it "can send an event to self" $ do
+--        let
+--          childHandler :: TestAction -> Int -> (Int -> Int, [DirectedEvent String TestAction])
+--          childHandler Up   _ = (const 1, [Self Down])
+--          childHandler Down _ = (const 0, [])
+--
+--          parentHandler :: String -> String -> (String -> String, [DirectedEvent String String])
+--          parentHandler "hello" _ = (const "bye", [])
+--          parentHandler "bye" _ = (const "hello", [])
+--          parentHandler str _ = (const str, [])
+--
+--          reducer =
+--            handler ("" :: String) parentHandler
+--              $ \message ->
+--                  div
+--                  [ text message
+--                  , handler (0 :: Int)
+--                      childHandler
+--                      (text . show)
+--                  ]
+--
+--        chan <- newTChanIO
+--
+--        let locatedGraph = fst $ prepareTree reducer
+--
+--        render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
+--
+--        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
+--
+--        afterEvent1 <- apply chan event1 locatedGraph
+--
+--        receivedEvent1 <- atomically $ readTChan chan
+--        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
+--
+--        receivedEvent2 <- atomically $ readTChan chan
+--        -- correctly targeted to self
+--        receivedEvent2 `shouldBe` Event {event = "internal", message = String "Down", location = Just [1,0]}
 
-    it "changes state" $ do
+  describe "findEvent" $ do
+    it "works" $ do
       let
-        actionHandler :: String -> Int -> (Int -> Int, [DirectedEvent () String])
-        actionHandler "up" _ = (const 1, [])
-        actionHandler _    _ = (const 0, [])
+        clickHandler :: (Int -> Purview String IO) -> Purview () IO
+        clickHandler = handler (0 :: Int) reducer
 
-        reducer :: Purview () IO
-        reducer =
-          handler (0 :: Int)
-            actionHandler
-            (Text . show)
+        reducer :: String -> Int -> (Int -> Int, [DirectedEvent () String])
+        reducer "up" st = (const 0, [])
+        reducer "down" st = (const 1, [])
 
-      render reducer
+        tree = clickHandler $ const $ div [ onClick "up" $ div [ text "up" ] ]
+        treeWithLocations = addLocations tree
+
+        -- EffectHandler Just [] Just [] "0" div [  Attr On "click" Just [0,0] div [  "up" ]  ]
+        event = Event { event="click", message=Just [0, 0], location=Just [] }
+
+      findEvent event treeWithLocations
         `shouldBe`
-        "<div handler=\"null\">0</div>"
-
-      chan <- newTChanIO
-
-      let event' = Event { event="click", message="up", location=Nothing }
-
-      appliedHandler <- apply chan event' reducer
-
-      stateEvent <- atomically $ readTChan chan
-
-      show stateEvent `shouldBe` show (StateChangeEvent (id :: Int -> Int) Nothing)
-
-      afterState <- apply chan stateEvent appliedHandler
-
-      render afterState
-        `shouldBe`
-        "<div handler=\"null\">1</div>"
-
-    it "works for clicks across many different trees" $
-      property $ \x -> do
-        let event = Event { event="click", message="up", location=Nothing }
-        chan <- newTChanIO
-
-        component <- apply chan event (x :: Purview String IO)
-        render component `shouldContain` "always present"
-
-    it "works for setting state across many different trees" $
-      property $ \x -> do
-        let event = Event { event="newState", message="up", location=Just [] }
-        chan <- newTChanIO
-
-        component <- apply chan event (x :: Purview String IO)
-        -- this tests 2 things
-        -- 1. that it fully goes down the tree
-        -- 2. the component remains the same, since the event doesn't
-        --    have a location that matches anything
-        component `shouldBe` x
-
-    it "works with typed messages" $ do
-      let
-        actionHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
-        actionHandler Up   _ = (const 1, [])
-        actionHandler Down _ = (const 0, [])
-
-        reducer =
-          handler (0 :: Int)
-            actionHandler
-            (Text . show)
-
-      render reducer
-        `shouldBe`
-        "<div handler=\"null\">0</div>"
-
-      chan <- newTChanIO
-
-      let event' = Event { event="click", message=toJSON Up, location=Nothing }
-
-      appliedHandler <- apply chan event' reducer
-
-      stateEvent <- atomically $ readTChan chan
-
-      afterState <- apply chan stateEvent appliedHandler
-
-      render afterState
-        `shouldBe`
-        "<div handler=\"null\">1</div>"
-
-    it "works after sending an event that did not match anything" $ do
-      let
-        actionHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
-        actionHandler Up   _ = (const 1, [])
-        actionHandler Down _ = (const 0, [])
-
-        reducer =
-          handler (0 :: Int)
-            actionHandler
-            (Text . show)
-
-      chan <- newTChanIO
-
-      let event0 = Event { event="init", message="init", location=Nothing }
-
-      appliedHandler0 <- apply chan event0 reducer
-      render appliedHandler0
-        `shouldBe`
-        "<div handler=\"null\">0</div>"
-
-      let event1 = Event { event="init", message=toJSON Up, location=Nothing }
-
-      appliedHandler1 <- apply chan event1 appliedHandler0
-
-      stateEvent <- atomically $ readTChan chan
-      appliedHandler2 <- apply chan stateEvent appliedHandler1
-
-      render appliedHandler2
-        `shouldBe`
-        "<div handler=\"null\">1</div>"
-
-    it "works with a nested attribute" $ do
-      let
-        childHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
-        childHandler Up   _ = (const 1, [Parent "hello"])
-        childHandler Down _ = (const 0, [])
-
-        parentHandler :: String -> String -> (Id String, [DirectedEvent String String])
-        parentHandler "hello" _ = (const "bye", [])
-        parentHandler "bye" _ = (const "hello", [])
-        parentHandler str _ = (const str, [])
-
-        styledContainer = style "font-size: 10px;" . div
-
-        reducer =
-          handler ("" :: String) parentHandler
-            $ \message ->
-                styledContainer
-                [ text message
-                , handler (0 :: Int)
-                    childHandler
-                    (text . show)
-                ]
-
-        component = reducer
-
-      chan <- newTChanIO
-
-      let
-        locatedGraph = fst $ prepareTree component
-        event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
-
-      afterEvent1 <- apply chan event1 locatedGraph
-
-      receivedEvent1 <- atomically $ readTChan chan
-      show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
-
-      receivedEvent2 <- atomically $ readTChan chan
-      receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
-
-    describe "sending events" $ do
-
-      it "can send an event to a parent" $ do
-        let
-          childHandler :: TestAction -> Int -> (Id Int, [DirectedEvent String TestAction])
-          childHandler Up   _ = (const 1, [Parent "hello"])
-          childHandler Down _ = (const 0, [])
-
-          parentHandler :: String -> String -> (Id String, [DirectedEvent String String])
-          parentHandler "hello" _ = (const "bye", [])
-          parentHandler "bye" _ = (const "hello", [])
-          parentHandler str _ = (const str, [])
-
-          reducer =
-            handler ("" :: String) parentHandler
-              $ \message ->
-                  div
-                  [ text message
-                  , handler (0 :: Int)
-                      childHandler
-                      (text . show)
-                  ]
-
-        chan <- newTChanIO
-
-        let locatedGraph = fst $ prepareTree reducer
-
-        render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
-
-        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
-
-        afterEvent1 <- apply chan event1 locatedGraph
-
-        receivedEvent1 <- atomically $ readTChan chan
-        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
-
-        receivedEvent2 <- atomically $ readTChan chan
-        -- correctly targeted to the parent
-        receivedEvent2 `shouldBe` Event {event = "internal", message = String "hello", location = Just []}
-
-
-      it "can send an event to self" $ do
-        let
-          childHandler :: TestAction -> Int -> (Int -> Int, [DirectedEvent String TestAction])
-          childHandler Up   _ = (const 1, [Self Down])
-          childHandler Down _ = (const 0, [])
-
-          parentHandler :: String -> String -> (String -> String, [DirectedEvent String String])
-          parentHandler "hello" _ = (const "bye", [])
-          parentHandler "bye" _ = (const "hello", [])
-          parentHandler str _ = (const str, [])
-
-          reducer =
-            handler ("" :: String) parentHandler
-              $ \message ->
-                  div
-                  [ text message
-                  , handler (0 :: Int)
-                      childHandler
-                      (text . show)
-                  ]
-
-        chan <- newTChanIO
-
-        let locatedGraph = fst $ prepareTree reducer
-
-        render locatedGraph `shouldBe` "<div handler=\"[]\"><div><div handler=\"[1,0]\">0</div></div></div>"
-
-        let event1 = Event { event="click", message=toJSON Up, location=Just [1, 0] }
-
-        afterEvent1 <- apply chan event1 locatedGraph
-
-        receivedEvent1 <- atomically $ readTChan chan
-        show receivedEvent1 `shouldBe` show (StateChangeEvent (id :: Int -> Int) (Just [1, 0]))
-
-        receivedEvent2 <- atomically $ readTChan chan
-        -- correctly targeted to self
-        receivedEvent2 `shouldBe` Event {event = "internal", message = String "Down", location = Just [1,0]}
-
+        (Just $ AnyEvent ("up" :: String))
 
 main :: IO ()
 main = hspec spec

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -302,7 +302,7 @@ spec = parallel $ do
 
       findEvent event treeWithLocations
         `shouldBe`
-        (Just $ AnyEvent ("up" :: String))
+        (Just $ AnyEvent ("up" :: String) Nothing Nothing)
 
 main :: IO ()
 main = hspec spec

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -56,9 +56,9 @@ eventLoop devMode runner log eventBus connection component = do
 
   -- this is where handlers are actually called, and their events are sent back into
   -- this loop
-  void . forkIO $ do
-    newEvents <- runner $ runEvent message newTree'
-    mapM_ (atomically . writeTChan eventBus) newEvents
+--  void . forkIO $ do
+--    newEvents <- runner $ runEvent message newTree'
+--    mapM_ (atomically . writeTChan eventBus) newEvents
 
   -- TODO: restore when changing handlers
   -- mapM_ (atomically . writeTChan eventBus) actions

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -47,7 +47,7 @@ eventLoop devMode runner log eventBus connection component = do
     -- this collects any actions that should run once and sets them
     -- to "run" in the tree, while assigning locations / identifiers
     -- to the event handlers
-    (newTree, actions) = prepareTree component
+    newTree = addLocations component
 
   -- if it's special newState event, the state is replaced in the tree
   let newTree' = case message of
@@ -60,7 +60,8 @@ eventLoop devMode runner log eventBus connection component = do
     newEvents <- runner $ runEvent message newTree'
     mapM_ (atomically . writeTChan eventBus) newEvents
 
-  mapM_ (atomically . writeTChan eventBus) actions
+  -- TODO: restore when changing handlers
+  -- mapM_ (atomically . writeTChan eventBus) actions
 
   let
     -- collect diffs

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -39,10 +39,7 @@ data Event where
     } -> Event
 
   StateChangeEvent
-    :: ( Eq state
-       , Typeable state
-       , ToJSON state
-       , FromJSON state)
+    :: ( Eq state, Typeable state )
     => (state -> state) -> Maybe [Int] -> Event
 
 instance Show Event where

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -34,7 +34,7 @@ handlers higher up in the tree.
 data Event where
   Event ::
     { event :: Text
-    , message :: Value
+    , message :: Maybe [Int]
     , location :: Maybe [Int]
     } -> Event
 

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -53,6 +53,12 @@ addLocations' parentLocation location component = case component of
     in
       EffectHandler (Just parentLocation) (Just location) state handler cont'
 
+  Handler _ploc _loc state handler cont ->
+    let
+      cont' = fmap (\child -> addLocations' location (location <> [0]) child) cont
+    in
+      Handler (Just parentLocation) (Just location) state handler cont'
+
   Text val -> Text val
 
   Value val -> Value val
@@ -80,6 +86,14 @@ prepareTree' parentLocation location component = case component of
       rest = fmap (prepareTree' location (0:location)) cont
     in
       ( EffectHandler (Just parentLocation) (Just location) state handler (\state' -> fst (rest state'))
+      , snd (rest state)
+      )
+
+  Handler _ploc _loc state handler cont ->
+    let
+      rest = fmap (prepareTree' location (0:location)) cont
+    in
+      ( Handler (Just parentLocation) (Just location) state handler (\state' -> fst (rest state'))
       , snd (rest state)
       )
 

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -83,23 +83,23 @@ prepareTree' parentLocation location component = case component of
       , snd (rest state)
       )
 
-  Once effect hasRun cont ->
-    let send message =
-          Event
-            { event = "once"
-            , message = toJSON message
-            , location = Just location
-            }
-    in if not hasRun then
-        let
-          rest = prepareTree' parentLocation location cont
-        in
-          (Once effect True (fst rest), [effect send] <> (snd rest))
-       else
-        let
-          rest = prepareTree' parentLocation location cont
-        in
-          (Once effect True (fst rest), snd rest)
+--  Once effect hasRun cont ->
+--    let send message =
+--          Event
+--            { event = "once"
+--            , message = toJSON message
+--            , location = Just location
+--            }
+--    in if not hasRun then
+--        let
+--          rest = prepareTree' parentLocation location cont
+--        in
+--          (Once effect True (fst rest), [effect send] <> (snd rest))
+--       else
+--        let
+--          rest = prepareTree' parentLocation location cont
+--        in
+--          (Once effect True (fst rest), snd rest)
 
   Value x -> (Value x, [])
 

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -5,7 +5,7 @@ import Test.Hspec
 import Test.QuickCheck
 import Data.Time
 
-import TreeGenerator
+import TreeGenerator ()
 import Events
 import Component
 import PrepareTree
@@ -23,14 +23,16 @@ spec = parallel $ do
             [ onClick "setTime" $ div []
             , onClick "clearTime" $ div []
             ]
-          (preparedTarget, _) = prepareTree target
+          fixedTree = addLocations [] [] target
 
-      preparedTarget
+      fixedTree
         `shouldBe`
         Html "div"
-          [ Attribute (On "click" Nothing "setTime" ) $ Html "div" []
-          , Attribute (On "click" Nothing "clearTime" ) $ Html "div" []
+          [ Attribute (On "click" (Just [0]) "setTime" ) $ Html "div" []
+          , Attribute (On "click" (Just [1]) "clearTime" ) $ Html "div" []
           ]
+
+    -- TODO: Nested On actions
 
     it "sets hasRun to True" $ do
       let
@@ -53,7 +55,7 @@ spec = parallel $ do
 
       show (fst (prepareTree component))
         `shouldBe`
-        "EffectHandler Just [] Just [] \"null\" Once True div [  \"Nothing\" Attr div [  \"check time\" ]  ] "
+        "EffectHandler Just [] Just [] \"null\" Once True div [  \"Nothing\" Attr On \"click\" Just [1,0] div [  \"check time\" ]  ] "
 
       length (snd (prepareTree component))
         `shouldBe`

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -23,7 +23,7 @@ spec = parallel $ do
             [ onClick "setTime" $ div []
             , onClick "clearTime" $ div []
             ]
-          fixedTree = addLocations [] [] target
+          fixedTree = addLocations target
 
       fixedTree
         `shouldBe`
@@ -34,60 +34,60 @@ spec = parallel $ do
 
     -- TODO: Nested On actions
 
-    it "sets hasRun to True" $ do
-      let
-        display time = div
-          [ text (show time)
-          , onClick ("setTime" :: String) $ div [ text "check time" ]
-          ]
-
-        startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
-
-        timeHandler = EffectHandler Nothing Nothing Nothing handle
-
-        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
-        handle "setTime" _     = do
-          time <- getCurrentTime
-          pure (const $ Just time, [])
-        handle _         state = pure (const state, [])
-
-        component = timeHandler (startClock display)
-
-      show (fst (prepareTree component))
-        `shouldBe`
-        "EffectHandler Just [] Just [] \"null\" Once True div [  \"Nothing\" Attr On \"click\" Just [1,0] div [  \"check time\" ]  ] "
-
-      length (snd (prepareTree component))
-        `shouldBe`
-        1
-
-    it "stops collecting the action if it has already run" $ do
-      let
-        display time = div
-          [ text (show time)
-          , onClick ("setTime" :: String) $ div [ text "check time" ]
-          ]
-
-        startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
-
-        timeHandler = EffectHandler Nothing Nothing Nothing handle
-
-        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
-        handle "setTime" _     = do
-          time <- getCurrentTime
-          pure (const $ Just time, [])
-        handle _         state = pure (const state, [])
-
-        component = timeHandler (startClock display)
-
-      let
-        run1 = prepareTree component
-        run2 = prepareTree (fst run1)
-        run3 = prepareTree (fst run2)
-
-      length (snd run1) `shouldBe` 1
-      length (snd run2) `shouldBe` 0
-      length (snd run3) `shouldBe` 0  -- for a bug where it was resetting run
+--    it "sets hasRun to True" $ do
+--      let
+--        display time = div
+--          [ text (show time)
+--          , onClick ("setTime" :: String) $ div [ text "check time" ]
+--          ]
+--
+--        startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
+--
+--        timeHandler = EffectHandler Nothing Nothing Nothing handle
+--
+--        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
+--        handle "setTime" _     = do
+--          time <- getCurrentTime
+--          pure (const $ Just time, [])
+--        handle _         state = pure (const state, [])
+--
+--        component = timeHandler (startClock display)
+--
+--      show (fst (prepareTree component))
+--        `shouldBe`
+--        "EffectHandler Just [] Just [] \"null\" Once True div [  \"Nothing\" Attr On \"click\" Just [1,0] div [  \"check time\" ]  ] "
+--
+--      length (snd (prepareTree component))
+--        `shouldBe`
+--        1
+--
+--    it "stops collecting the action if it has already run" $ do
+--      let
+--        display time = div
+--          [ text (show time)
+--          , onClick ("setTime" :: String) $ div [ text "check time" ]
+--          ]
+--
+--        startClock cont state = Once (\send -> send ("setTime" :: String)) False (cont state)
+--
+--        timeHandler = EffectHandler Nothing Nothing Nothing handle
+--
+--        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
+--        handle "setTime" _     = do
+--          time <- getCurrentTime
+--          pure (const $ Just time, [])
+--        handle _         state = pure (const state, [])
+--
+--        component = timeHandler (startClock display)
+--
+--      let
+--        run1 = prepareTree component
+--        run2 = prepareTree (fst run1)
+--        run3 = prepareTree (fst run2)
+--
+--      length (snd run1) `shouldBe` 1
+--      length (snd run2) `shouldBe` 0
+--      length (snd run3) `shouldBe` 0  -- for a bug where it was resetting run
 
     it "assigns a location to handlers" $ do
       let
@@ -127,7 +127,7 @@ spec = parallel $ do
 
       show graphWithLocation
         `shouldBe`
-        "div [  EffectHandler Just [] Just [0] \"null\" \"\" EffectHandler Just [] Just [1] \"null\" \"\" ] "
+        "div [  EffectHandler Just [] Just [0] Nothing \"\" EffectHandler Just [] Just [1] Nothing \"\" ] "
 
     it "assigns a different location to nested handlers" $ do
       let
@@ -145,7 +145,7 @@ spec = parallel $ do
 
         graphWithLocation = fst (prepareTree component)
 
-      show graphWithLocation `shouldBe` "EffectHandler Just [] Just [] \"null\" EffectHandler Just [] Just [0] \"null\" \"\""
+      show graphWithLocation `shouldBe` "EffectHandler Just [] Just [] Nothing EffectHandler Just [] Just [0] Nothing \"\""
 
 
 main :: IO ()

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -18,6 +18,20 @@ spec = parallel $ do
     it "works across a variety of trees" $ do
       property $ \x -> show (fst (prepareTree (x :: Purview String IO))) `shouldContain` "always present"
 
+    it "assigns an identifier to On actions" $ do
+      let target = div
+            [ onClick "setTime" $ div []
+            , onClick "clearTime" $ div []
+            ]
+          (preparedTarget, _) = prepareTree target
+
+      preparedTarget
+        `shouldBe`
+        Html "div"
+          [ Attribute (On "click" Nothing "setTime" ) $ Html "div" []
+          , Attribute (On "click" Nothing "clearTime" ) $ Html "div" []
+          ]
+
     it "sets hasRun to True" $ do
       let
         display time = div

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -165,7 +165,7 @@ renderFullPage :: Configuration event m -> Purview action m -> Builder
 renderFullPage Configuration { htmlHead, htmlEventHandlers } component =
   fromString
   $ wrapHtml htmlHead htmlEventHandlers
-  $ render . fst
+  $ render
   $ addLocations component
 
 startWebSocketLoop

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -166,7 +166,7 @@ renderFullPage Configuration { htmlHead, htmlEventHandlers } component =
   fromString
   $ wrapHtml htmlHead htmlEventHandlers
   $ render . fst
-  $ prepareTree component
+  $ addLocations component
 
 startWebSocketLoop
   :: Monad m

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -176,7 +176,7 @@ startWebSocketLoop
   -> IO ()
 startWebSocketLoop Configuration { devMode, interpreter, logger } component connection = do
   eventBus <- newTChanIO
-  atomically $ writeTChan eventBus $ Event { event = "init", message = "init", location = Nothing }
+  -- atomically $ writeTChan eventBus $ Event { event = "init", message = "init", location = Nothing }
 
   WebSocket.withPingThread connection 30 (pure ()) $ do
     _ <- forkIO $ webSocketMessageHandler eventBus connection
@@ -185,6 +185,8 @@ startWebSocketLoop Configuration { devMode, interpreter, logger } component conn
 webSocketMessageHandler :: TChan Event -> WebSocket.Connection -> IO ()
 webSocketMessageHandler eventBus websocketConnection = do
   message' <- WebSocket.receiveData websocketConnection
+
+  print (show message')
 
   case decode message' of
     Just fromEvent -> atomically $ writeTChan eventBus fromEvent

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -7,7 +7,7 @@ import           Unsafe.Coerce
 import           Component
 
 isOn :: Attributes a -> Bool
-isOn (On _ _) = True
+isOn (On _ _ _) = True
 isOn _        = False
 
 isGeneric :: Attributes a -> Bool
@@ -31,7 +31,7 @@ renderAttributes attrs =
 
     listeners = filter isOn attrs
     renderedListeners = concatMap
-      (\(On name action) -> " action=" <> (unpack $ encode action))
+      (\(On name ident action) -> " action=" <> (unpack $ encode action))
       listeners
 
     generics = filter isGeneric attrs

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -66,6 +66,11 @@ render' attrs tree = case tree of
       render' attrs (unsafeCoerce cont state) <>
     "</div>"
 
+  Handler parentLocation location state _ cont ->
+    "<div handler=" <> (show . encode) location <> ">" <>
+      render' attrs (unsafeCoerce cont state) <>
+    "</div>"
+
   Once _ _hasRun cont ->
     render' attrs cont
 

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -31,7 +31,7 @@ renderAttributes attrs =
 
     listeners = filter isOn attrs
     renderedListeners = concatMap
-      (\(On name ident action) -> " action=" <> (unpack $ encode action))
+      (\(On name ident action) -> " location=" <> (unpack $ encode ident))
       listeners
 
     generics = filter isGeneric attrs

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -13,6 +13,7 @@ import Events
 import Rendering
 
 data SingleConstructor = SingleConstructor
+  deriving (Show, Eq)
 
 $(deriveJSON (defaultOptions{tagSingleConstructors=True}) ''SingleConstructor)
 
@@ -32,11 +33,11 @@ spec = parallel $ do
 
     it "can add an onclick" $ do
       let element =
-            Attribute (On "click" (1 :: Integer))
+            Attribute (On "click" Nothing (1 :: Integer))
             $ Html "div" [Text "hello world"]
 
       render element `shouldBe`
-        "<div action=1>hello world</div>"
+        "<div location=null>hello world</div>"
 
     it "can add an id" $ do
       let element = identifier "hello" $ div [text "it's a hello div"]
@@ -68,14 +69,14 @@ spec = parallel $ do
 
       render component
         `shouldBe`
-        "<form action=\"initialValue\"><input name=\"name\"></input></form>"
+        "<form location=null><input name=\"name\"></input></form>"
 
     it "can render a typed action" $ do
       let element = onClick SingleConstructor $ div [ text "click" ]
 
       render element
         `shouldBe`
-        "<div action=\"SingleConstructor\">click</div>"
+        "<div location=null>click</div>"
 
     it "can render a style" $ do
       let element = style "color: blue;" $ div [ text "blue" ]

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -23,8 +23,6 @@ testHandler = effectHandler ("" :: String) reducer
     reducer :: String -> String -> IO (String -> String, [DirectedEvent String String])
     reducer action state = pure (const "", [])
 
-testOnce = once (\send -> send "")
-
 sizedArbExpr :: Int -> Gen (Purview String IO)
 sizedArbExpr 0 = do pure $ text "always present"
 sizedArbExpr n = do
@@ -33,7 +31,6 @@ sizedArbExpr n = do
     [ div es
     , style "" $ div es
     , testHandler (const $ div es)
-    , testOnce (div es)
     ]
 
 instance Arbitrary (Purview String IO) where

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -19,15 +19,15 @@ clickEventHandlingFunction = [r|
 
     var clickValue;
     try {
-      clickValue = JSON.parse(event.target.getAttribute("action"));
+      clickLocation = JSON.parse(event.target.getAttribute("location"));
     } catch (error) {
       // if the action is just a string, parsing it as JSON would fail
-      clickValue = event.target.getAttribute("action");
+      clickLocation = event.target.getAttribute("location");
     }
     var location = JSON.parse(event.currentTarget.getAttribute("handler"))
 
-    if (clickValue) {
-      window.ws.send(JSON.stringify({ "event": "click", "message": clickValue, "location": location }));
+    if (clickLocation) {
+      window.ws.send(JSON.stringify({ "event": "click", "message": clickLocation, "location": location }));
     }
   }
 |]

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -17,6 +17,8 @@ clickEventHandlingFunction = [r|
   function handleClickEvents(event) {
     event.stopPropagation();
 
+    console.log(event)
+
     var clickValue;
     try {
       clickLocation = JSON.parse(event.target.getAttribute("location"));
@@ -138,10 +140,14 @@ websocketScript = [r|
 
 wrapHtml :: String -> [HtmlEventHandler] -> String -> String
 wrapHtml htmlHead htmlEventHandlers body =
-  "<html>"
+  "<!DOCTYPE html>"
+  <> "<html>"
   <> "<head>"
-  <> "<script>" <> websocketScript <> bindEvents htmlEventHandlers <> "bindEvents();" <> "</script>"
+  <> "<script>" <> websocketScript <> bindEvents htmlEventHandlers <> "</script>"
   <> htmlHead
   <> "</head>"
-  <> "<body>"<> body <> "</body>"
+  <> "<body>"
+  <> body
+  <> "<script>bindEvents();</script>"
+  <> "</body>"
   <> "</html>"


### PR DESCRIPTION
Now instead of events being put into the HTML as encoded JSON, we're just using locations.  This could be swapped I think for using a Map or something that'll be much faster, but this proves out the idea.

1. Give event creators a location
2. That location is what is sent back on clicks
3. It's looked up in the server-side tree
4. The event applied to the handler

Next thing to figure out is receiving data from the front end (again) with the forms, and cleaning all this up.