### PR TITLE
Refactor handlers

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -46,9 +46,9 @@ dependencies:
 - blaze-builder                 >= 0.4.2 && < 0.5
 - http-types                    >= 0.12.3 && < 0.13
 
-# - hspec #
-# - QuickCheck #
-# - time #
+- hspec #
+- QuickCheck #
+- time #
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -46,9 +46,9 @@ dependencies:
 - blaze-builder                 >= 0.4.2 && < 0.5
 - http-types                    >= 0.12.3 && < 0.13
 
-- hspec #
-- QuickCheck #
-- time #
+# - hspec #
+# - QuickCheck #
+# - time #
 
 library:
   source-dirs: src

--- a/purview.cabal
+++ b/purview.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -56,14 +56,17 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      aeson >=2.0.3 && <2.1
+      QuickCheck
+    , aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
+    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
+    , time
     , websockets >=0.12.7 && <0.13
   default-language: Haskell2010
 
@@ -118,16 +121,19 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      aeson >=2.0.3 && <2.1
+      QuickCheck
+    , aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
     , criterion >=1.5.13 && <1.6
+    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
+    , time
     , websockets >=0.12.7 && <0.13
   buildable: False
   default-language: Haskell2010

--- a/purview.cabal
+++ b/purview.cabal
@@ -56,17 +56,14 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      QuickCheck
-    , aeson >=2.0.3 && <2.1
+      aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
-    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
-    , time
     , websockets >=0.12.7 && <0.13
   default-language: Haskell2010
 
@@ -121,19 +118,16 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      QuickCheck
-    , aeson >=2.0.3 && <2.1
+      aeson >=2.0.3 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.1 && <0.12
     , criterion >=1.5.13 && <1.6
-    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
     , text >=1.2.5 && <1.3
-    , time
     , websockets >=0.12.7 && <0.13
   buildable: False
   default-language: Haskell2010

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -54,6 +54,8 @@ data Purview event m where
   EffectHandler
     :: ( Show state
        , Eq state
+       , Typeable state
+       , Typeable newEvent
        )
     => { parentIdentifier :: ParentIdentifier
        -- ^ The location of the parent effect handler (provided by prepareTree)
@@ -73,6 +75,8 @@ data Purview event m where
   Handler
     :: ( Show state
        , Eq state
+       , Typeable state
+       , Typeable newEvent
        )
     => { parentIdentifier :: ParentIdentifier
        , identifier       :: Identifier
@@ -138,7 +142,8 @@ handler
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
-handler initEvents state = Handler Nothing Nothing initEvents state
+handler initEvents state reducer cont =
+  Handler Nothing Nothing initEvents state reducer cont
 
 {-|
 
@@ -172,7 +177,8 @@ effectHandler
   -> (state -> Purview event m)
   -- ^ continuation
   -> Purview parentEvent m
-effectHandler = EffectHandler Nothing Nothing
+effectHandler initEvents state reducer cont =
+  EffectHandler Nothing Nothing initEvents state reducer cont
 
 {-
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -17,7 +17,8 @@ are applied during rendering.
 
 -}
 data Attributes event where
-  On :: (Eq event, Typeable event, Show event) => String -> Identifier -> event -> Attributes event
+  On
+    :: (Eq event, Typeable event, Show event) => String -> Identifier -> event -> Attributes event
   -- ^ part of creating handlers for different events, e.g. On "click"
   Style :: String -> Attributes event
   -- ^ inline css
@@ -88,13 +89,6 @@ data Purview event m where
     -> (state -> Purview newEvent m)
     -> Purview event m
 
-  Once
-    :: (ToJSON event)
-    => ((event -> Event) -> Event)
-    -> Bool  -- has run
-    -> Purview event m
-    -> Purview event m
-
 instance Show (Purview event m) where
   show (EffectHandler parentLocation location state _event cont) =
     "EffectHandler "
@@ -108,7 +102,6 @@ instance Show (Purview event m) where
     <> show location <> " "
     <> show state <> " "
     <> show (cont state)
-  show (Once _ hasRun cont) = "Once " <> show hasRun <> " " <> show cont
   show (Attribute attrs cont) = "Attr " <> show attrs <> " " <> show cont
   show (Text str) = show str
   show (Html kind children) =
@@ -181,19 +174,6 @@ effectHandler
   -> Purview parentEvent m
 effectHandler state =
   EffectHandler Nothing Nothing state
-
-{-|
-
-This is for kicking off loading events.  Put it beneath one of your handlers
-to send an event up to it, and it will only be sent once.
-
--}
-once
-  :: ToJSON event
-  => ((event -> Event) -> Event)
-  -> Purview event m
-  -> Purview event m
-once sendEvent = Once sendEvent False
 
 {-
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -180,6 +180,14 @@ effectHandler
 effectHandler initEvents state reducer cont =
   EffectHandler Nothing Nothing initEvents state reducer cont
 
+defaultHandler :: (() -> Purview () m) -> Purview () m
+defaultHandler =
+  Handler Nothing Nothing [] () (\event state -> (const (), []))
+
+defaultEffectHandler :: Applicative m => (() -> Purview () m) -> Purview () m
+defaultEffectHandler =
+  EffectHandler Nothing Nothing [] () (\event state -> pure (const (), []))
+
 {-
 
 Helpers

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -38,9 +38,6 @@ instance Show (Attributes event) where
   show (Style str) = "Style " <> show str
   show (Generic attrKey attrValue) = "Generic " <> show attrKey <> show attrValue
 
-type Identifier = Maybe [Int]
-type ParentIdentifier = Identifier
-
 {-|
 
 This is what you end up building using the various helpers.  It's hopefully rare

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -68,7 +68,7 @@ data Purview event m where
     -- ^ The location of this effect handler (provided by prepareTree)
     -> state
     -- ^ The initial state
-    -> (newEvent-> state -> m (state -> state, [DirectedEvent event newEvent]))
+    -> (newEvent -> state -> m (state -> state, [DirectedEvent event newEvent]))
     -- ^ Receive an event, change the state, and send messages
     -> (state -> Purview newEvent m)
     -- ^ Continuation
@@ -247,8 +247,8 @@ on the frontend.
 onSubmit :: (Typeable event, Eq event, Show event) => event -> Purview event m -> Purview event m
 onSubmit = Attribute . On "submit" Nothing
 
---identifier :: String -> Purview event m -> Purview event m
---identifier = Attribute . Generic "id"
+ident :: String -> Purview event m -> Purview event m
+ident = Attribute . Generic "id"
 
 classes :: [String] -> Purview event m -> Purview event m
 classes xs = Attribute . Generic "class" $ unwords xs

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -94,16 +94,16 @@ data Purview event m where
 instance Show (Purview event m) where
   show (EffectHandler parentLocation location state _event cont) =
     "EffectHandler "
-    <> show parentLocation <> " "
-    <> show location <> " "
-    <> show state <> " "
-    <> show (cont state)
+      <> show parentLocation <> " "
+      <> show location <> " "
+      <> show state <> " "
+      <> show (cont state)
   show (Handler parentLocation location initialEvents state _event cont) =
     "Handler "
-    <> show parentLocation <> " "
-    <> show location <> " "
-    <> show state <> " "
-    <> show (cont state)
+      <> show parentLocation <> " "
+      <> show location <> " "
+      <> show state <> " "
+      <> show (cont state)
   show (Attribute attrs cont) = "Attr " <> show attrs <> " " <> show cont
   show (Text str) = show str
   show (Html kind children) =
@@ -136,6 +136,7 @@ handler
      , Typeable state
      )
   => [DirectedEvent parentEvent event]
+  -- ^ Initial events to fire
   -> state
   -- ^ The initial state
   -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -54,8 +54,6 @@ data Purview event m where
   EffectHandler
     :: ( Show state
        , Eq state
-       , Typeable state
-       , Typeable newEvent
        )
     => { parentIdentifier :: ParentIdentifier
        -- ^ The location of the parent effect handler (provided by prepareTree)
@@ -75,8 +73,6 @@ data Purview event m where
   Handler
     :: ( Show state
        , Eq state
-       , Typeable state
-       , Typeable newEvent
        )
     => { parentIdentifier :: ParentIdentifier
        , identifier       :: Identifier
@@ -142,7 +138,7 @@ handler
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
-handler = Handler Nothing Nothing
+handler initEvents state = Handler Nothing Nothing initEvents state
 
 {-|
 

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -57,20 +57,15 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
 
   -- TODO: add Handler
   (EffectHandler _ loc initEvents state _ cont, EffectHandler _ loc' initEvents' newState _ newCont) ->
-    case cast state of
-      Just state' ->
-        [Update location newGraph | state' /= newState && loc == loc']
-        -- TODO: this is weak, instead of walking the whole tree it should be targetted
-        --       to specific effect handlers
+    [Update location newGraph | unsafeCoerce state /= newState && loc == loc']
+      -- TODO: this is weak, instead of walking the whole tree it should be targetted
+      --       to specific effect handlers
 
-        -- if we hit the target, we're already saying update the whole tree
-        <> if Just location == target
-           then []
-           else diff target (0:location) (unsafeCoerce cont state) (unsafeCoerce newCont newState)
+      -- if we hit the target, we're already saying update the whole tree
+      <> if Just location == target
+         then []
+         else diff target (0:location) (unsafeCoerce cont state) (unsafeCoerce newCont newState)
 
-      -- different kinds of state
-      Nothing ->
-        [Update location newGraph]
 
   (Attribute attr a, Attribute attr' b) ->
     [Update location newGraph | attr /= attr']

--- a/src/Diffing.hs
+++ b/src/Diffing.hs
@@ -56,7 +56,7 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
     [Update location newGraph]
 
   -- TODO: add Handler
-  (EffectHandler _ loc state _ cont, EffectHandler _ loc' newState _ newCont) ->
+  (EffectHandler _ loc initEvents state _ cont, EffectHandler _ loc' initEvents' newState _ newCont) ->
     case cast state of
       Just state' ->
         [Update location newGraph | state' /= newState && loc == loc']
@@ -78,7 +78,7 @@ diff target location oldGraph newGraph = case (oldGraph, newGraph) of
   (Value _, _) ->
     [Update location newGraph]
 
-  (EffectHandler _ _ _ _ _, _) ->
+  (EffectHandler _ _ _ _ _ _, _) ->
     [Update location newGraph]
 
   (_, _) -> [Update location newGraph]

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -40,8 +40,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = handler "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
-          handler2 = handler "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler1 = handler [] "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler2 = handler [] "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -53,8 +53,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -66,8 +66,8 @@ spec = parallel $ do
       it "continues going down the tree even if the state is the same at the top" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = fst . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
           newTree = fst . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 
@@ -75,6 +75,7 @@ spec = parallel $ do
           [ Update [0, 0] (EffectHandler
                             (Just [0])
                             (Just [0, 0])
+                            []
                             "different state"
                             (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
                             (const (text "this is different")))

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -68,8 +68,8 @@ spec = parallel $ do
           handler1 :: (String -> Purview String IO) -> Purview String IO
           handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          oldTree = fst . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
-          newTree = fst . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
+          oldTree = snd . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
+          newTree = snd . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 
         diff (Just [0, 0]) [] oldTree newTree `shouldBe`
           [ Update [0, 0] (EffectHandler

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -50,7 +50,7 @@ applyNewState (Event {}) component = component
 
 findEvent :: Event -> Purview event m -> Maybe AnyEvent
 findEvent (StateChangeEvent _ _) _ = Nothing
-findEvent event@Event { message=childLocation, location=handlerLocation } tree = case tree of
+findEvent event@Event { childLocation=childLocation, location=handlerLocation } tree = case tree of
   Attribute attr cont -> case attr of
     On _ ident evt ->
       if ident == childLocation

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -48,22 +48,6 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
 applyNewState (Event {}) component = component
 
 
-data AnyEvent where
-  AnyEvent ::
-    ( Show event
-    , Typeable event
-    , Eq event
-    ) => { event :: event, childId :: Identifier, handlerId :: Identifier } -> AnyEvent
-
--- TODO: these instances are incomplete (see now hanving identifiers)
-instance Show AnyEvent where
-  show (AnyEvent evt _ _) = show evt
-
-instance Eq AnyEvent where
-  (AnyEvent evt _ _) == (AnyEvent evt' _ _) = case cast evt' of
-    Just evt'' -> evt == evt''
-    Nothing    -> False
-
 findEvent :: Event -> Purview event m -> Maybe AnyEvent
 findEvent (StateChangeEvent _ _) _ = Nothing
 findEvent event@Event { message=childLocation, location=handlerLocation } tree = case tree of

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -48,7 +48,7 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
 applyNewState (Event {}) component = component
 
 
-findEvent :: Event -> Purview event m -> Maybe AnyEvent
+findEvent :: Event -> Purview event m -> Maybe Event
 findEvent (StateChangeEvent _ _) _ = Nothing
 findEvent event@Event { childLocation=childLocation, location=handlerLocation } tree = case tree of
   Attribute attr cont -> case attr of
@@ -75,7 +75,7 @@ findEvent event@Event { childLocation=childLocation, location=handlerLocation } 
   Value _ -> Nothing
 
 -- TODO: continue down the tree
-runEvent :: Monad m => AnyEvent -> Purview event m -> m [Event]
+runEvent :: Monad m => Event -> Purview event m -> m [Event]
 runEvent anyEvent@AnyEvent { event, handlerId } tree = case tree of
   Attribute attr cont ->
     runEvent anyEvent cont
@@ -85,7 +85,6 @@ runEvent anyEvent@AnyEvent { event, handlerId } tree = case tree of
   EffectHandler _ ident initEvents state handler cont -> case cast event of
     Just event' -> do
       (newStateFn, events) <- handler event' state
-
       pure [StateChangeEvent newStateFn handlerId]
     Nothing -> pure []
 

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -41,10 +41,12 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
 
   Value x -> Value x
 applyNewState (Event {}) component = component
+applyNewState (AnyEvent {}) component = component
 
 
 findEvent :: Event -> Purview event m -> Maybe Event
-findEvent (StateChangeEvent _ _) _ = Nothing
+findEvent (StateChangeEvent {}) _ = Nothing
+findEvent (AnyEvent {}) _ = Nothing
 findEvent event@Event { childLocation=childLocation, location=handlerLocation } tree = case tree of
   Attribute attr cont -> case attr of
     On _ ident evt ->

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -42,9 +42,6 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
   Attribute n cont ->
     Attribute n (applyNewState fromEvent cont)
 
-  Once fn run cont ->
-    Once fn run $ applyNewState fromEvent cont
-
   Text x -> Text x
 
   Value x -> Value x

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -30,11 +30,11 @@ applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case 
       let children = fmap (applyNewState fromEvent) cont
       in EffectHandler ploc loc state handler children
 
-  Handler ploc loc state handler cont -> case cast newStateFn of
-    Just newStateFn' -> Handler ploc loc (newStateFn' state) handler cont
+  Handler ploc loc initEvents state handler cont -> case cast newStateFn of
+    Just newStateFn' -> Handler ploc loc initEvents (newStateFn' state) handler cont
     Nothing ->
       let children = fmap (applyNewState fromEvent) cont
-      in Handler ploc loc state handler children
+      in Handler ploc loc initEvents state handler children
 
   Html kind children ->
     Html kind $ fmap (applyNewState fromEvent) children
@@ -83,7 +83,7 @@ findEvent event@Event { message=childLocation, location=handlerLocation } tree =
   EffectHandler _ ident state _ cont ->
     findEvent event (cont state)
 
-  Handler _ ident state _ cont ->
+  Handler _ ident initEvents state _ cont ->
     findEvent event (cont state)
 
   Text _ -> Nothing
@@ -105,7 +105,7 @@ runEvent anyEvent@AnyEvent { event, handlerId } tree = case tree of
       pure [StateChangeEvent newStateFn handlerId]
     Nothing -> pure []
 
-  Handler _ ident state handler cont -> case cast event of
+  Handler _ ident initEvents state handler cont -> case cast event of
     Just event' ->
       let (newStateFn, events) = handler event' state
       in pure [StateChangeEvent newStateFn handlerId]

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -24,11 +24,11 @@ applyNewState
   -> Purview event m
   -> Purview event m
 applyNewState fromEvent@(StateChangeEvent newStateFn location) component = case component of
-  EffectHandler ploc loc state handler cont -> case cast newStateFn of
-    Just newStateFn' -> EffectHandler ploc loc (newStateFn' state) handler cont
+  EffectHandler ploc loc initEvents state handler cont -> case cast newStateFn of
+    Just newStateFn' -> EffectHandler ploc loc initEvents (newStateFn' state) handler cont
     Nothing ->
       let children = fmap (applyNewState fromEvent) cont
-      in EffectHandler ploc loc state handler children
+      in EffectHandler ploc loc initEvents state handler children
 
   Handler ploc loc initEvents state handler cont -> case cast newStateFn of
     Just newStateFn' -> Handler ploc loc initEvents (newStateFn' state) handler cont
@@ -80,7 +80,7 @@ findEvent event@Event { message=childLocation, location=handlerLocation } tree =
       []      -> Nothing
       _       -> Nothing
 
-  EffectHandler _ ident state _ cont ->
+  EffectHandler _ ident initEvents state _ cont ->
     findEvent event (cont state)
 
   Handler _ ident initEvents state _ cont ->
@@ -98,7 +98,7 @@ runEvent anyEvent@AnyEvent { event, handlerId } tree = case tree of
 
   Html _ children -> concat <$> mapM (runEvent anyEvent) children
 
-  EffectHandler _ ident state handler cont -> case cast event of
+  EffectHandler _ ident initEvents state handler cont -> case cast event of
     Just event' -> do
       (newStateFn, events) <- handler event' state
 

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -302,7 +302,7 @@ spec = parallel $ do
 
       findEvent event' treeWithLocations
         `shouldBe`
-        (Just $ AnyEvent ("up" :: String) Nothing Nothing)
+        (Just $ AnyEvent ("up" :: String) (Just [0, 0]) (Just []))
 
 main :: IO ()
 main = hspec spec

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -295,12 +295,12 @@ spec = parallel $ do
         reducer "down" st = (const 1, [])
 
         tree = clickHandler $ const $ div [ onClick "up" $ div [ text "up" ] ]
-        treeWithLocations = addLocations tree
+        (_, treeWithLocations) = prepareTree tree
 
         -- EffectHandler Just [] Just [] "0" div [  Attr On "click" Just [0,0] div [  "up" ]  ]
-        event = Event { event="click", message=Just [0, 0], location=Just [] }
+        event' = Event { kind="click", childLocation=Just [0, 0], location=Just [] }
 
-      findEvent event treeWithLocations
+      findEvent event' treeWithLocations
         `shouldBe`
         (Just $ AnyEvent ("up" :: String) Nothing Nothing)
 

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -288,7 +288,7 @@ spec = parallel $ do
     it "works" $ do
       let
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
-        clickHandler = handler (0 :: Int) reducer
+        clickHandler = handler [] (0 :: Int) reducer
 
         reducer :: String -> Int -> (Int -> Int, [DirectedEvent () String])
         reducer "up" st = (const 0, [])

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -10,6 +10,7 @@ import           Control.Concurrent.STM.TChan
 import           Control.Monad.STM
 import           Control.Monad
 import           Control.Concurrent
+import           Data.Typeable
 import           Data.Aeson (encode)
 import qualified Network.WebSockets as WebSockets
 
@@ -31,7 +32,7 @@ type Log m = String -> m ()
 -- the html with the new.
 --
 eventLoop
-  :: Monad m
+  :: (Monad m, Typeable event)
   => Bool
   -> (m [Event] -> IO [Event])
   -> Log IO

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -47,8 +47,11 @@ eventLoop devMode runner log eventBus connection component = do
     -- this collects any actions that should run once and sets them
     -- to "run" in the tree, while assigning locations / identifiers
     -- to the event handlers
-    newTree = addLocations component
+    (_, newTree) = prepareTree component
     event = findEvent message newTree
+
+  -- TODO: restore when changing handlers
+  -- mapM_ (atomically . writeTChan eventBus) actions
 
   print $ "event: " <> show event
 
@@ -64,9 +67,6 @@ eventLoop devMode runner log eventBus connection component = do
       Just event' -> runner $ runEvent event' newTree'
       Nothing     -> pure []
     mapM_ (atomically . writeTChan eventBus) newEvents
-
-  -- TODO: restore when changing handlers
-  -- mapM_ (atomically . writeTChan eventBus) actions
 
   let
     -- collect diffs

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -19,6 +19,7 @@ import           EventHandling
 import           Events
 import           PrepareTree
 import           Rendering
+import Component (Purview(initialEvents))
 
 type Log m = String -> m ()
 
@@ -47,11 +48,11 @@ eventLoop devMode runner log eventBus connection component = do
     -- this collects any actions that should run once and sets them
     -- to "run" in the tree, while assigning locations / identifiers
     -- to the event handlers
-    (_, newTree) = prepareTree component
+    (initialEvents, newTree) = prepareTree component
     event = findEvent message newTree
 
   -- TODO: restore when changing handlers
-  -- mapM_ (atomically . writeTChan eventBus) actions
+  -- mapM_ (atomically . writeTChan eventBus) initialEvents
 
   print $ "event: " <> show event
 

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -10,6 +10,7 @@ import           Data.Text (Text)
 import           Data.Typeable
 import           Data.Aeson
 import           GHC.Generics
+import           Unsafe.Coerce
 
 type Identifier = Maybe [Int]
 type ParentIdentifier = Identifier
@@ -46,7 +47,6 @@ data Event where
   AnyEvent
     :: ( Show event
        , Eq event
-       , Typeable event
        )
     => { event :: event
        , childId :: Identifier
@@ -85,9 +85,7 @@ instance Eq Event where
   (StateChangeEvent _ _) == _ = False
 
   (AnyEvent event childId handlerId) == (AnyEvent event' childId' handlerId') =
-    case cast event' of
-      Just event'' -> childId == childId' && handlerId == handlerId' && event == event''
-      Nothing -> False
+      childId == childId' && handlerId == handlerId' && event == unsafeCoerce event'
   (AnyEvent {}) == _ = False
 
 
@@ -103,8 +101,8 @@ or sent back in to the same handler.
 
 -}
 data DirectedEvent a b where
-  Parent :: (Show a, Typeable a, Eq a) => a -> DirectedEvent a b
-  Self :: (Show b, Typeable b, Eq b) => b -> DirectedEvent a b
+  Parent :: (Show a, Eq a) => a -> DirectedEvent a b
+  Self :: (Show b, Eq b) => b -> DirectedEvent a b
 
 -- data AnyEvent where
 --   AnyEvent

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -75,8 +75,8 @@ or sent back in to the same handler.
 
 -}
 data DirectedEvent a b where
-  Parent :: (ToJSON a, Show a, Typeable a, Eq a) => a -> DirectedEvent a b
-  Self :: (ToJSON b, Show b, Typeable b, Eq b) => b -> DirectedEvent a b
+  Parent :: (Show a, Typeable a, Eq a) => a -> DirectedEvent a b
+  Self :: (Show b, Typeable b, Eq b) => b -> DirectedEvent a b
 
 data AnyEvent where
   AnyEvent

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -10,7 +10,6 @@ import           Data.Text (Text)
 import           Data.Typeable
 import           Data.Aeson
 import           GHC.Generics
-import           Unsafe.Coerce
 
 type Identifier = Maybe [Int]
 type ParentIdentifier = Identifier
@@ -86,7 +85,9 @@ instance Eq Event where
   (StateChangeEvent _ _) == _ = False
 
   (AnyEvent event childId handlerId) == (AnyEvent event' childId' handlerId') =
-      childId == childId' && handlerId == handlerId' && event == unsafeCoerce event'
+    case cast event of
+      Just castEvent -> childId == childId' && handlerId == handlerId' && castEvent == event'
+      Nothing        -> False
   (AnyEvent {}) == _ = False
 
 
@@ -105,22 +106,3 @@ data DirectedEvent a b where
   Parent :: (Show a, Eq a) => a -> DirectedEvent a b
   Self :: (Show b, Eq b) => b -> DirectedEvent a b
 
--- data AnyEvent where
---   AnyEvent
---     :: ( Show event
---        , Typeable event
---        , Eq event
---        )
---     => { event :: event
---        , childId :: Identifier
---        , handlerId :: Identifier
---        } -> AnyEvent
-
--- TODO: these instances are incomplete (see now having identifiers)
--- instance Show AnyEvent where
---   show (AnyEvent evt _ _) = show evt
---
--- instance Eq AnyEvent where
---   (AnyEvent evt _ _) == (AnyEvent evt' _ _) = case cast evt' of
---     Just evt'' -> evt == evt''
---     Nothing    -> False

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -35,16 +35,28 @@ handlers higher up in the tree.
 
 -}
 data Event where
-  Event ::
-    { event :: Text
-    -- ^ for example, "click" or "blur"
-    , childLocation :: Maybe [Int]
-    , location :: Maybe [Int]
-    } -> Event
+  Event
+    :: { kind :: Text
+       -- ^ for example, "click" or "blur"
+       , childLocation :: Identifier
+       , location :: Identifier
+       }
+    -> Event
+
+  AnyEvent
+    :: ( Show event
+       , Eq event
+       , Typeable event
+       )
+    => { event :: event
+       , childId :: Identifier
+       , handlerId :: Identifier
+       }
+    -> Event
 
   StateChangeEvent
     :: ( Eq state, Typeable state )
-    => (state -> state) -> Maybe [Int] -> Event
+    => (state -> state) -> Identifier -> Event
 
 instance Show Event where
   show (Event event message location) =
@@ -58,8 +70,8 @@ instance Show Event where
     "{ event: \"newState\", location: " <> show location <> " }"
 
 instance Eq Event where
-  (Event { childLocation=messageA, event=eventA, location=locationA })
-    == (Event { childLocation=messageB, event=eventB, location=locationB }) =
+  (Event { childLocation=messageA, kind=eventA, location=locationA })
+    == (Event { childLocation=messageB, kind=eventB, location=locationB }) =
     eventA == eventB && messageA == messageB && locationA == locationB
   (Event {}) == _ = False
   (StateChangeEvent _ _) == _ = False
@@ -79,22 +91,22 @@ data DirectedEvent a b where
   Parent :: (Show a, Typeable a, Eq a) => a -> DirectedEvent a b
   Self :: (Show b, Typeable b, Eq b) => b -> DirectedEvent a b
 
-data AnyEvent where
-  AnyEvent
-    :: ( Show event
-       , Typeable event
-       , Eq event
-       )
-    => { event :: event
-       , childId :: Identifier
-       , handlerId :: Identifier
-       } -> AnyEvent
+-- data AnyEvent where
+--   AnyEvent
+--     :: ( Show event
+--        , Typeable event
+--        , Eq event
+--        )
+--     => { event :: event
+--        , childId :: Identifier
+--        , handlerId :: Identifier
+--        } -> AnyEvent
 
 -- TODO: these instances are incomplete (see now having identifiers)
-instance Show AnyEvent where
-  show (AnyEvent evt _ _) = show evt
-
-instance Eq AnyEvent where
-  (AnyEvent evt _ _) == (AnyEvent evt' _ _) = case cast evt' of
-    Just evt'' -> evt == evt''
-    Nothing    -> False
+-- instance Show AnyEvent where
+--   show (AnyEvent evt _ _) = show evt
+--
+-- instance Eq AnyEvent where
+--   (AnyEvent evt _ _) == (AnyEvent evt' _ _) = case cast evt' of
+--     Just evt'' -> evt == evt''
+--     Nothing    -> False

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -66,15 +66,30 @@ instance Show Event where
       <> show message
       <> ", location: "
       <> show location <> " }"
+
   show (StateChangeEvent _ location) =
     "{ event: \"newState\", location: " <> show location <> " }"
+
+  show (AnyEvent event childId handlerId)
+    =  "{ event: " <> show event
+    <> ", childId: " <> show childId
+    <> ", handlerId: " <> show handlerId
+    <> " }"
 
 instance Eq Event where
   (Event { childLocation=messageA, kind=eventA, location=locationA })
     == (Event { childLocation=messageB, kind=eventB, location=locationB }) =
     eventA == eventB && messageA == messageB && locationA == locationB
   (Event {}) == _ = False
+
   (StateChangeEvent _ _) == _ = False
+
+  (AnyEvent event childId handlerId) == (AnyEvent event' childId' handlerId') =
+    case cast event' of
+      Just event'' -> childId == childId' && handlerId == handlerId' && event == event''
+      Nothing -> False
+  (AnyEvent {}) == _ = False
+
 
 instance FromJSON Event where
   parseJSON (Object o) =

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -47,6 +47,7 @@ data Event where
   AnyEvent
     :: ( Show event
        , Eq event
+       , Typeable event
        )
     => { event :: event
        , childId :: Identifier
@@ -55,7 +56,7 @@ data Event where
     -> Event
 
   StateChangeEvent
-    :: ( Eq state, Show state )
+    :: ( Eq state, Show state, Typeable state )
     => (state -> state) -> Identifier -> Event
 
 instance Show Event where

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -37,7 +37,8 @@ handlers higher up in the tree.
 data Event where
   Event ::
     { event :: Text
-    , message :: Maybe [Int]
+    -- ^ for example, "click" or "blur"
+    , childLocation :: Maybe [Int]
     , location :: Maybe [Int]
     } -> Event
 
@@ -49,7 +50,7 @@ instance Show Event where
   show (Event event message location) =
     show $ "{ event: "
       <> show event
-      <> ", message: "
+      <> ", childLocation: "
       <> show message
       <> ", location: "
       <> show location <> " }"
@@ -57,15 +58,15 @@ instance Show Event where
     "{ event: \"newState\", location: " <> show location <> " }"
 
 instance Eq Event where
-  (Event { message=messageA, event=eventA, location=locationA })
-    == (Event { message=messageB, event=eventB, location=locationB }) =
+  (Event { childLocation=messageA, event=eventA, location=locationA })
+    == (Event { childLocation=messageB, event=eventB, location=locationB }) =
     eventA == eventB && messageA == messageB && locationA == locationB
   (Event {}) == _ = False
   (StateChangeEvent _ _) == _ = False
 
 instance FromJSON Event where
   parseJSON (Object o) =
-      Event <$> o .: "event" <*> (o .: "message") <*> o .: "location"
+      Event <$> o .: "event" <*> (o .: "childLocation") <*> o .: "location"
   parseJSON _ = error "fail"
 
 {-|

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -55,7 +55,7 @@ data Event where
     -> Event
 
   StateChangeEvent
-    :: ( Eq state, Typeable state )
+    :: ( Eq state, Show state )
     => (state -> state) -> Identifier -> Event
 
 instance Show Event where

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -53,11 +53,11 @@ addLocations' parentLocation location component = case component of
     in
       EffectHandler (Just parentLocation) (Just location) state handler cont'
 
-  Handler _ploc _loc state handler cont ->
+  Handler _ploc _loc initEvents state handler cont ->
     let
       cont' = fmap (\child -> addLocations' location (location <> [0]) child) cont
     in
-      Handler (Just parentLocation) (Just location) state handler cont'
+      Handler (Just parentLocation) (Just location) initEvents state handler cont'
 
   Text val -> Text val
 
@@ -89,11 +89,11 @@ prepareTree' parentLocation location component = case component of
       , snd (rest state)
       )
 
-  Handler _ploc _loc state handler cont ->
+  Handler _ploc _loc initEvents state handler cont ->
     let
       rest = fmap (prepareTree' location (0:location)) cont
     in
-      ( Handler (Just parentLocation) (Just location) state handler (\state' -> fst (rest state'))
+      ( Handler (Just parentLocation) (Just location) initEvents state handler (\state' -> fst (rest state'))
       , snd (rest state)
       )
 

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -45,11 +45,11 @@ addLocations' parentLocation location component = case component of
     in
       Html kind children'
 
-  EffectHandler _ploc _loc state handler cont ->
+  EffectHandler _ploc _loc initEvents state handler cont ->
     let
       cont' = fmap (\child -> addLocations' location (location <> [0]) child) cont
     in
-      EffectHandler (Just parentLocation) (Just location) state handler cont'
+      EffectHandler (Just parentLocation) (Just location) initEvents state handler cont'
 
   Handler _ploc _loc initEvents state handler cont ->
     let
@@ -79,11 +79,11 @@ prepareTree' parentLocation location component = case component of
     let result = fmap (\(index, child) -> prepareTree' parentLocation (index:location) child) (zip [0..] children)
     in (Html kind (fmap fst result), concatMap snd result)
 
-  EffectHandler _ploc _loc state handler cont ->
+  EffectHandler _ploc _loc initEvents state handler cont ->
     let
       rest = fmap (prepareTree' location (0:location)) cont
     in
-      ( EffectHandler (Just parentLocation) (Just location) state handler (\state' -> fst (rest state'))
+      ( EffectHandler (Just parentLocation) (Just location) initEvents state handler (\state' -> fst (rest state'))
       , snd (rest state)
       )
 

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -52,7 +52,7 @@ prepareTree' parentLocation location component = case component of
       cont' = fmap (prepareTree' location (location <> [0])) cont
     in
       ( fmap (directedEventToAnyEvent parentLocation location) initEvents
-      , EffectHandler (Just parentLocation) (Just location) initEvents state handler (snd . cont')
+      , EffectHandler (Just parentLocation) (Just location) [] state handler (snd . cont')
       )
 
   Handler _ploc _loc initEvents state handler cont ->
@@ -60,7 +60,7 @@ prepareTree' parentLocation location component = case component of
       cont' = fmap (prepareTree' location (location <> [0])) cont
     in
       ( fmap (directedEventToAnyEvent parentLocation location) initEvents
-      , Handler (Just parentLocation) (Just location) initEvents state handler (snd . cont')
+      , Handler (Just parentLocation) (Just location) [] state handler (snd . cont')
       )
 
   Text val -> ([], Text val)

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 module PrepareTree where
 
+import Data.Typeable
+
 import Component
 import Events
 
@@ -14,7 +16,7 @@ else to actually send the actions.
 It also assigns a location to message and effect handlers.
 
 -}
-prepareTree :: Purview event m -> ([Event], Purview event m)
+prepareTree :: Typeable event => Purview event m -> ([Event], Purview event m)
 prepareTree = prepareTree' [] []
 
 type Location = [Int]
@@ -24,12 +26,12 @@ addLocationToAttr loc attr = case attr of
   On str _ event' -> On str (Just loc) event'
   _               -> attr
 
-directedEventToAnyEvent :: Location -> Location -> DirectedEvent a b -> Event
+directedEventToAnyEvent :: (Typeable a, Typeable b) => Location -> Location -> DirectedEvent a b -> Event
 directedEventToAnyEvent parentLocation location directedEvent = case directedEvent of
   Parent event -> AnyEvent { event=event, childId=Nothing, handlerId=Just parentLocation }
   Self event   -> AnyEvent { event=event, childId=Nothing, handlerId=Just location }
 
-prepareTree' :: Location -> Location -> Purview event m -> ([Event], Purview event m)
+prepareTree' :: Typeable event => Location -> Location -> Purview event m -> ([Event], Purview event m)
 prepareTree' parentLocation location component = case component of
   Attribute attr cont ->
     let

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 module PrepareTree where
 
-import Data.Aeson
-
 import Component
 import Events
 
@@ -96,24 +94,6 @@ prepareTree' parentLocation location component = case component of
       ( Handler (Just parentLocation) (Just location) initEvents state handler (\state' -> fst (rest state'))
       , snd (rest state)
       )
-
---  Once effect hasRun cont ->
---    let send message =
---          Event
---            { event = "once"
---            , message = toJSON message
---            , location = Just location
---            }
---    in if not hasRun then
---        let
---          rest = prepareTree' parentLocation location cont
---        in
---          (Once effect True (fst rest), [effect send] <> (snd rest))
---       else
---        let
---          rest = prepareTree' parentLocation location cont
---        in
---          (Once effect True (fst rest), snd rest)
 
   Value x -> (Value x, [])
 

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -14,7 +14,7 @@ else to actually send the actions.
 It also assigns a location to message and effect handlers.
 
 -}
-prepareTree :: Purview event m -> ([AnyEvent], Purview event m)
+prepareTree :: Purview event m -> ([Event], Purview event m)
 prepareTree = prepareTree' [] []
 
 type Location = [Int]
@@ -24,12 +24,12 @@ addLocationToAttr loc attr = case attr of
   On str _ event' -> On str (Just loc) event'
   _               -> attr
 
-directedEventToAnyEvent :: Location -> Location -> DirectedEvent a b -> AnyEvent
+directedEventToAnyEvent :: Location -> Location -> DirectedEvent a b -> Event
 directedEventToAnyEvent parentLocation location directedEvent = case directedEvent of
   Parent event -> AnyEvent { event=event, childId=Nothing, handlerId=Just parentLocation }
   Self event   -> AnyEvent { event=event, childId=Nothing, handlerId=Just location }
 
-prepareTree' :: Location -> Location -> Purview event m -> ([AnyEvent], Purview event m)
+prepareTree' :: Location -> Location -> Purview event m -> ([Event], Purview event m)
 prepareTree' parentLocation location component = case component of
   Attribute attr cont ->
     let

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -34,21 +34,45 @@ spec = parallel $ do
 
     -- TODO: Nested On actions
 
-    it "collects initial events" $ do
-      let
-        handler' = handler [Self "up"] "" handle
+    describe "collecting initial events" $ do
 
-        handle "up" _ = (id, [])
+      it "works for handlers" $ do
+        let
+          handler' = handler [Self "up"] "" handle
 
-        (initialActions, component) = prepareTree (handler' (const $ div []))
+          handle "up" _ = (id, [])
 
-      initialActions `shouldBe` [AnyEvent "up" Nothing (Just [])]
+          (initialActions, component) = prepareTree (handler' (const $ div []))
 
-      -- the next round there should be no initial actions
-      let
-        (initialActions', component') = prepareTree component
+        initialActions `shouldBe` [AnyEvent "up" Nothing (Just [])]
 
-      initialActions' `shouldBe` []
+        -- the next round there should be no initial actions
+        let
+          (initialActions', component') = prepareTree component
+
+        initialActions' `shouldBe` []
+
+      it "works for effectHandler" $ do
+        let
+          handler' = effectHandler [Self "up"] "" handle
+
+          handle "up" _ = pure (id, []) :: IO (a -> a, [DirectedEvent () String])
+
+          (initialActions, component) = prepareTree (handler' (const $ div []))
+
+        initialActions `shouldBe` [AnyEvent "up" Nothing (Just [])]
+
+        -- the next round there should be no initial actions
+        let
+          (initialActions', component') = prepareTree component
+
+        initialActions' `shouldBe` []
+
+      it "works for nested handlers" $ do
+        let
+          handler' = Handler Nothing Nothing [Self "up", Parent 0]
+
+        1 `shouldBe` 1
 
     it "assigns a location to handlers" $ do
       let

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -91,7 +91,7 @@ spec = parallel $ do
 
     it "assigns a location to handlers" $ do
       let
-        timeHandler = effectHandler Nothing handle
+        timeHandler = effectHandler [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
@@ -101,16 +101,16 @@ spec = parallel $ do
 
         component = timeHandler (const (Text ""))
 
-      component `shouldBe` (EffectHandler Nothing Nothing Nothing handle (const (Text "")))
+      component `shouldBe` (EffectHandler Nothing Nothing [] Nothing handle (const (Text "")))
 
       let
         graphWithLocation = fst (prepareTree component)
 
-      graphWithLocation `shouldBe` (EffectHandler (Just []) (Just []) Nothing handle (const (Text "")))
+      graphWithLocation `shouldBe` (EffectHandler (Just []) (Just []) [] Nothing handle (const (Text "")))
 
     it "assigns a different location to child handlers" $ do
       let
-        timeHandler = effectHandler Nothing handle
+        timeHandler = effectHandler [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
@@ -131,7 +131,7 @@ spec = parallel $ do
 
     it "assigns a different location to nested handlers" $ do
       let
-        timeHandler = effectHandler Nothing handle
+        timeHandler = effectHandler [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NoMonomorphismRestriction #-}
 module PrepareTreeSpec where
 
 import Prelude hiding (div)
@@ -39,6 +38,7 @@ spec = parallel $ do
 
       it "works for handlers" $ do
         let
+          handler' :: (String -> Purview String IO) -> Purview () IO
           handler' = handler [Self "up"] "" handle
 
           handle "up" _ = (id, [])
@@ -69,11 +69,12 @@ spec = parallel $ do
 
         initialActions' `shouldBe` []
 
-      it "works for nested handlers" $ do
-        let
-          handler' = Handler
-
-        1 `shouldBe` 1
+        -- TODO: this
+--      it "works for nested handlers" $ do
+--        let
+--          handler' = Handler
+--
+--        1 `shouldBe` 1
 
     it "assigns a location to handlers" $ do
       let

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NoMonomorphismRestriction #-}
 module PrepareTreeSpec where
 
 import Prelude hiding (div)
@@ -70,7 +71,7 @@ spec = parallel $ do
 
       it "works for nested handlers" $ do
         let
-          handler' = Handler Nothing Nothing [Self "up", Parent 0]
+          handler' = Handler
 
         1 `shouldBe` 1
 

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -166,7 +166,8 @@ renderFullPage Configuration { htmlHead, htmlEventHandlers } component =
   fromString
   $ wrapHtml htmlHead htmlEventHandlers
   $ render
-  $ addLocations component
+  $ snd
+  $ prepareTree component
 
 startWebSocketLoop
   :: Monad m

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -177,7 +177,8 @@ startWebSocketLoop
   -> IO ()
 startWebSocketLoop Configuration { devMode, interpreter, logger } component connection = do
   eventBus <- newTChanIO
-  -- atomically $ writeTChan eventBus $ Event { event = "init", message = "init", location = Nothing }
+
+  atomically $ writeTChan eventBus $ Event { kind = "init", childLocation = Nothing, location = Nothing }
 
   WebSocket.withPingThread connection 30 (pure ()) $ do
     _ <- forkIO $ webSocketMessageHandler eventBus connection

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -12,7 +12,7 @@ downButton :: Purview String m
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
 reducer :: Applicative m => (Int -> Purview String m) -> Purview String m
-reducer = handler 0 action
+reducer = handler [] 0 action
   where
     action :: String -> Int -> (Int -> Int, [DirectedEvent String String])
     action "up" _ = (const 1, [])
@@ -26,7 +26,7 @@ counter state = div
   ]
 
 component :: Applicative m => Purview String m
-component = reducer counter
+component = PurviewSpec.reducer counter
 
 event' :: String
 event' = "{\"event\":\"click\",\"message\":\"up\"}"

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -62,7 +62,7 @@ render' attrs tree = case tree of
   Attribute attr rest ->
     render' (attr:attrs) rest
 
-  EffectHandler parentLocation location state _ cont ->
+  EffectHandler parentLocation location initEvents state _ cont ->
     "<div handler=" <> (show . encode) location <> ">" <>
       render' attrs (unsafeCoerce cont state) <>
     "</div>"

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 module Rendering where
 
 import           Data.Aeson
@@ -8,11 +9,11 @@ import           Component
 
 isOn :: Attributes a -> Bool
 isOn (On _ _ _) = True
-isOn _        = False
+isOn _          = False
 
 isGeneric :: Attributes a -> Bool
 isGeneric (Generic _ _) = True
-isGeneric _ = False
+isGeneric _             = False
 
 getStyle :: Attributes a -> String
 getStyle (Style style') = style'
@@ -21,7 +22,7 @@ getStyle _              = ""
 renderGeneric :: Attributes a -> String
 renderGeneric attr = case attr of
   (Generic name value) -> " " <> name <> "=" <> unpack (encode value)
-  _ -> ""
+  _                    -> ""
 
 renderAttributes :: [Attributes a] -> String
 renderAttributes attrs =
@@ -66,9 +67,9 @@ render' attrs tree = case tree of
       render' attrs (unsafeCoerce cont state) <>
     "</div>"
 
-  Handler parentLocation location state _ cont ->
-    "<div handler=" <> (show . encode) location <> ">" <>
-      render' attrs (unsafeCoerce cont state) <>
+  Handler { identifier, state, continuation } ->
+    "<div handler=" <> (show . encode) identifier <> ">" <>
+      render' attrs (unsafeCoerce continuation state) <>
     "</div>"
 
   Value a -> show a

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -71,7 +71,4 @@ render' attrs tree = case tree of
       render' attrs (unsafeCoerce cont state) <>
     "</div>"
 
-  Once _ _hasRun cont ->
-    render' attrs cont
-
   Value a -> show a

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -40,7 +40,7 @@ spec = parallel $ do
         "<div location=null>hello world</div>"
 
     it "can add an id" $ do
-      let element = identifier "hello" $ div [text "it's a hello div"]
+      let element = ident "hello" $ div [text "it's a hello div"]
       render element `shouldBe` "<div id=\"hello\">it's a hello div</div>"
 
     it "can add one class" $ do
@@ -56,7 +56,7 @@ spec = parallel $ do
     it "can render classes and ids at the same time" $ do
       let element =
             classes ["class1", "class2", "class3"]
-            $ identifier "hello"
+            $ ident "hello"
             $ div [text "it's a hello div"]
       render element `shouldBe` "<div id=\"hello\" class=\"class1 class2 class3\">it's a hello div</div>"
 

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -18,7 +18,7 @@ nicely.
 -}
 
 testHandler :: (String -> Purview String IO) -> Purview String IO
-testHandler = effectHandler ("" :: String) reducer
+testHandler = effectHandler [] ("" :: String) reducer
   where
     reducer :: String -> String -> IO (String -> String, [DirectedEvent String String])
     reducer action state = pure (const "", [])

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -29,7 +29,7 @@ clickEventHandlingFunction = [r|
     var location = JSON.parse(event.currentTarget.getAttribute("handler"))
 
     if (clickLocation) {
-      window.ws.send(JSON.stringify({ "event": "click", "message": clickLocation, "location": location }));
+      window.ws.send(JSON.stringify({ "event": "click", "childLocation": clickLocation, "location": location }));
     }
   }
 |]


### PR DESCRIPTION
This changes it so that handlers take an argument for initial events (as in events that should be run once loaded)

Todo:
- [x] Remove the unsafe coerces (turns out they aren't needed, I just ran into the problem with monomorphisation restriction)
- [x] Remove the test deps
- [x] Check that using a default record works for effect/handlers

The default record way should work for newer versions of GHC, see https://gitlab.haskell.org/ghc/ghc/-/issues/16501