### PR TITLE
First step to restoring forms

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -66,6 +66,7 @@ library:
       - PrepareTreeSpec
       - PurviewSpec
       - RenderingSpec
+      - EventsSpec
       - Spec
 
 # executables:

--- a/purview.cabal
+++ b/purview.cabal
@@ -79,6 +79,7 @@ test-suite purview-test
       EventHandlingSpec
       EventLoop
       Events
+      EventsSpec
       PrepareTree
       PrepareTreeSpec
       Purview

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -15,7 +15,14 @@ are applied during rendering.
 
 -}
 data Attributes event where
-  On :: (Eq event, Typeable event, Show event) => String -> Identifier -> event -> Attributes event
+  On :: ( Eq event
+        , Typeable event
+        , Show event
+        )
+     => String
+     -> Identifier
+     -> (Maybe String -> event)  -- the string here is information from the browser
+     -> Attributes event
   -- ^ part of creating handlers for different events, e.g. On "click"
   Style :: String -> Attributes event
   -- ^ inline css
@@ -26,9 +33,9 @@ instance Eq (Attributes event) where
   (Style a) == (Style b) = a == b
   (Style _) == _ = False
 
-  (On kind ident event) == (On kind' ident' event') =
-    kind == kind' && event == event' && ident == ident'
-  (On _ _ _) == _ = False
+  (On kind ident _event) == (On kind' ident' _event') =
+    kind == kind' && ident == ident'
+  (On {}) == _ = False
 
   (Generic name value) == (Generic name' value') = name == name' && value == value'
   (Generic _ _) == _ = False
@@ -245,7 +252,7 @@ on the frontend.  It will be bound to whichever 'HTML' is beneath it.
 
 -}
 onClick :: (Typeable event, Eq event, Show event) => event -> Purview event m -> Purview event m
-onClick = Attribute . On "click" Nothing
+onClick = Attribute . On "click" Nothing . const
 
 {-|
 
@@ -253,7 +260,7 @@ This will send the event to the handler above it whenever "submit" is triggered
 on the frontend.
 
 -}
-onSubmit :: (Typeable event, Eq event, Show event) => event -> Purview event m -> Purview event m
+onSubmit :: (Typeable event, Eq event, Show event) => (Maybe String -> event) -> Purview event m -> Purview event m
 onSubmit = Attribute . On "submit" Nothing
 
 ident :: String -> Purview event m -> Purview event m

--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -68,11 +68,11 @@ applyNewState (InternalEvent {}) component = component
 findEvent :: Event -> Purview event m -> Maybe Event
 findEvent (StateChangeEvent {}) _ = Nothing
 findEvent (InternalEvent {}) _ = Nothing
-findEvent event@FromFrontendEvent { childLocation=childLocation, location=handlerLocation } tree = case tree of
+findEvent event@FromFrontendEvent { childLocation=childLocation, location=handlerLocation, value=value } tree = case tree of
   Attribute attr cont -> case attr of
     On _ ident evt ->
       if ident == childLocation
-      then Just $ InternalEvent evt childLocation handlerLocation
+      then Just $ InternalEvent (evt value) childLocation handlerLocation
       else Nothing
     _ -> findEvent event cont
 
@@ -124,3 +124,9 @@ runEvent internalEvent@InternalEvent { event, handlerId } tree = case tree of
   Text _ -> pure []
 
   Value _ -> pure []
+
+  -- TODO: this should never happen, should refactor so it's clear
+  EffectHandler { identifier = Nothing }       -> undefined
+  EffectHandler { parentIdentifier = Nothing } -> undefined
+  Handler { identifier = Nothing }             -> undefined
+  Handler { parentIdentifier = Nothing }       -> undefined

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -53,7 +53,7 @@ eventLoop devMode runner log eventBus connection component = do
     event = findEvent message newTree
 
   mapM_ (atomically . writeTChan eventBus) initialEvents
-
+  print $ "initialEvents: " <> show initialEvents
   print $ "event: " <> show event
 
   -- if it's special newState event, the state is replaced in the tree

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -66,7 +66,9 @@ instance Show Event where
       <> ", childLocation: "
       <> show message
       <> ", location: "
-      <> show location <> " }"
+      <> show location
+      <> ", value: "
+      <> show value <> " }"
 
   show (StateChangeEvent _ location) =
     "{ event: \"newState\", location: " <> show location <> " }"
@@ -78,9 +80,9 @@ instance Show Event where
     <> " }"
 
 instance Eq Event where
-  (FromFrontendEvent { childLocation=messageA, kind=eventA, location=locationA })
-    == (FromFrontendEvent { childLocation=messageB, kind=eventB, location=locationB }) =
-    eventA == eventB && messageA == messageB && locationA == locationB
+  (FromFrontendEvent { childLocation=messageA, kind=eventA, location=locationA, value=valueA })
+    == (FromFrontendEvent { childLocation=messageB, kind=eventB, location=locationB, value=valueB }) =
+    eventA == eventB && messageA == messageB && locationA == locationB && valueA == valueB
   (FromFrontendEvent {}) == _ = False
 
   (StateChangeEvent _ _) == _ = False
@@ -94,7 +96,7 @@ instance Eq Event where
 
 instance FromJSON Event where
   parseJSON (Object o) =
-      FromFrontendEvent <$> o .: "event" <*> (o .: "childLocation") <*> o .: "location" <*> o .: "value"
+      FromFrontendEvent <$> o .: "event" <*> (o .: "childLocation") <*> o .: "location" <*> o .:? "value"
   parseJSON _ = error "fail"
 
 {-|

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -40,7 +40,7 @@ data Event where
        -- ^ for example, "click" or "blur"
        , childLocation :: Identifier
        , location :: Identifier
-       , value :: Maybe Value
+       , value :: Maybe String
        }
     -> Event
 

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -10,6 +11,7 @@ import           Data.Text (Text)
 import           Data.Typeable
 import           Data.Aeson
 import           GHC.Generics
+
 
 type Identifier = Maybe [Int]
 type ParentIdentifier = Identifier
@@ -108,4 +110,3 @@ or sent back in to the same handler.
 data DirectedEvent a b where
   Parent :: (Show a, Eq a) => a -> DirectedEvent a b
   Self :: (Show b, Eq b) => b -> DirectedEvent a b
-

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -40,6 +40,7 @@ data Event where
        -- ^ for example, "click" or "blur"
        , childLocation :: Identifier
        , location :: Identifier
+       , value :: Maybe Value
        }
     -> Event
 
@@ -59,7 +60,7 @@ data Event where
     => (state -> state) -> Identifier -> Event
 
 instance Show Event where
-  show (FromFrontendEvent event message location) =
+  show (FromFrontendEvent event message location value) =
     show $ "{ event: "
       <> show event
       <> ", childLocation: "
@@ -93,7 +94,7 @@ instance Eq Event where
 
 instance FromJSON Event where
   parseJSON (Object o) =
-      FromFrontendEvent <$> o .: "event" <*> (o .: "childLocation") <*> o .: "location"
+      FromFrontendEvent <$> o .: "event" <*> (o .: "childLocation") <*> o .: "location" <*> o .: "value"
   parseJSON _ = error "fail"
 
 {-|

--- a/src/EventsSpec.hs
+++ b/src/EventsSpec.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+module EventsSpec where
+
+import Test.Hspec
+import Data.Aeson
+
+import Events
+import Data.Maybe (isNothing)
+
+
+spec :: SpecWith ()
+spec = parallel $ do
+
+  describe "parsing events" $ do
+    it "parses a FrontEndEvent with a value of nothing" $ do
+      decode "{ \"event\": \"click\", \"childLocation\": null, \"location\": null }"
+        `shouldBe`
+        Just (FromFrontendEvent { kind="click", childLocation=Nothing, location=Nothing, value=Nothing })
+
+    it "parses a FrontEndEvent with a string value" $ do
+      decode "{ \"event\": \"click\", \"childLocation\": null, \"location\": null, \"value\": \"hello\" }"
+        `shouldBe`
+        Just (FromFrontendEvent { kind="click", childLocation=Nothing, location=Nothing, value=Just "hello" })
+
+
+main :: IO ()
+main = hspec spec

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -34,8 +34,8 @@ spec = parallel $ do
       snd fixedTree
         `shouldBe`
         Html "div"
-          [ Attribute (On "click" (Just [0]) "setTime" ) $ Html "div" []
-          , Attribute (On "click" (Just [1]) "clearTime" ) $ Html "div" []
+          [ Attribute (On "click" (Just [0]) (const "setTime") ) $ Html "div" []
+          , Attribute (On "click" (Just [1]) (const "clearTime") ) $ Html "div" []
           ]
 
     -- TODO: Nested On actions

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -182,7 +182,7 @@ startWebSocketLoop Configuration { devMode, interpreter, logger } component conn
 
   atomically
     $ writeTChan eventBus
-    $ FromFrontendEvent { kind = "init", childLocation = Nothing, location = Nothing }
+    $ FromFrontendEvent { kind = "init", childLocation = Nothing, location = Nothing, value = Nothing }
 
   WebSocket.withPingThread connection 30 (pure ()) $ do
     _ <- forkIO $ webSocketMessageHandler eventBus connection

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -33,7 +33,7 @@ spec = parallel $ do
 
     it "can add an onclick" $ do
       let element =
-            Attribute (On "click" Nothing (1 :: Integer))
+            Attribute (On "click" Nothing (\_ -> 1 :: Integer))
             $ Html "div" [Text "hello world"]
 
       render element `shouldBe`
@@ -65,7 +65,7 @@ spec = parallel $ do
         named = Attribute . Generic "name"
         input = Html "input"
         form = Html "form"
-        component = onSubmit ("initialValue" :: String) $ form [ named "name" $ input [] ]
+        component = onSubmit (\_ -> "initialValue" :: String) $ form [ named "name" $ input [] ]
 
       render component
         `shouldBe`

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -48,7 +48,7 @@ submitEventHandlingFunction = [r|
     var location = JSON.parse(event.currentTarget.getAttribute("handler"))
 
     if (entries) {
-      window.ws.send(JSON.stringify({ "event": "submit", "message": entries, "location": location }));
+      window.ws.send(JSON.stringify({ "event": "submit", "value": entries, "location": location }));
     }
   }
 |]


### PR DESCRIPTION
This changes `On` so that event creation takes a `String`.  The idea here is that the front end can include a `value` in their message to the backend, which will then be applied to the event.

This allows passing in the stringified object from, for example, a form, to create the event.  This could then be turned into the real object higher up, but I'm thinking about making it `decode` automatically.  The reason not to is that makes things less clear to the programmer if there's a mismatch between the form and their object (they'd just keep getting `Nothing`)