### PR TITLE
Handle event bubbling

### DIFF
--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -32,7 +32,7 @@ renderAttributes attrs =
 
     listeners = filter isOn attrs
     renderedListeners = concatMap
-      (\(On name ident action) -> " " <> name <> "-location=" <> unpack (encode ident))
+      (\(On name ident action) -> " bubbling-bound " <> name <> "-location=" <> unpack (encode ident))
       listeners
 
     generics = filter isGeneric attrs

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -32,13 +32,14 @@ renderAttributes attrs =
 
     listeners = filter isOn attrs
     renderedListeners = concatMap
-      (\(On name ident action) -> " bubbling-bound " <> name <> "-location=" <> unpack (encode ident))
+      (\(On name ident action) -> " " <> name <> "-location=" <> unpack (encode ident))
       listeners
+    noticeToBind = if null listeners then "" else " bubbling-bound"
 
     generics = filter isGeneric attrs
     renderedGenerics = concatMap renderGeneric generics
   in
-    renderedStyle <> renderedListeners <> renderedGenerics
+    renderedStyle <> noticeToBind <> renderedListeners <> renderedGenerics
 
 {-|
 

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -38,7 +38,7 @@ spec = parallel $ do
             $ Html "div" [Text "hello world"]
 
       render element `shouldBe`
-        "<div click-location=null>hello world</div>"
+        "<div bubbling-bound click-location=null>hello world</div>"
 
     it "can add an id" $ do
       let element = id' "hello" $ div [text "it's a hello div"]
@@ -70,14 +70,14 @@ spec = parallel $ do
 
       render component
         `shouldBe`
-        "<form submit-location=null><input name=\"name\"></input></form>"
+        "<form bubbling-bound submit-location=null><input name=\"name\"></input></form>"
 
     it "can render a typed action" $ do
       let element = onClick SingleConstructor $ div [ text "click" ]
 
       render element
         `shouldBe`
-        "<div click-location=null>click</div>"
+        "<div bubbling-bound click-location=null>click</div>"
 
     it "can render two typed actions of different form" $ do
       let element
@@ -87,7 +87,7 @@ spec = parallel $ do
 
       render element
         `shouldBe`
-        "<div click-location=null submit-location=null>click</div>"
+        "<div bubbling-bound click-location=null submit-location=null>click</div>"
 
 
     it "can render a style" $ do


### PR DESCRIPTION
This fixes it so that event bubbling works like you'd expect.  Before if you clicked an element, and only the element above had the event location, no event would be sent.  Now if you click one, the event is enriched as it passes with the location which allows everything to work.