### PR TITLE
Change provided handlers

### DIFF
--- a/src/Component.hs
+++ b/src/Component.hs
@@ -135,7 +135,7 @@ For example, let's say you want to make a button that switches between saying
 > component = handler view
 
 -}
-handler
+handler'
   :: ( Typeable event
      , Show state
      , Eq state
@@ -150,7 +150,7 @@ handler
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
-handler initEvents state reducer cont =
+handler' initEvents state reducer cont =
   Handler Nothing Nothing initEvents state (constReducer reducer) cont
   where constReducer reducer event state =
           let (newState, events) = reducer event state
@@ -164,7 +164,7 @@ running pure calculation you may need to use this to avoid
 overwriting the state.
 
 -}
-handler'
+handler
   :: ( Typeable event
      , Show state
      , Eq state
@@ -179,7 +179,7 @@ handler'
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
-handler' initEvents state reducer cont =
+handler initEvents state reducer cont =
   Handler Nothing Nothing initEvents state reducer cont
 
 {-|
@@ -199,7 +199,7 @@ a button:
 > component = handler view
 
 -}
-effectHandler
+effectHandler'
   :: ( Typeable event
      , Show state
      , Eq state
@@ -215,7 +215,7 @@ effectHandler
   -> (state -> Purview event m)
   -- ^ continuation
   -> Purview parentEvent m
-effectHandler initEvents state reducer cont =
+effectHandler' initEvents state reducer cont =
   EffectHandler Nothing Nothing initEvents state (constReducer reducer) cont
   where constReducer reducer event state = fmap (Data.Bifunctor.first const) (reducer event state)
 
@@ -229,7 +229,7 @@ You'll want to use this if you're making a bunch of API requests to
 build up a list of results.
 
 -}
-effectHandler'
+effectHandler
   :: ( Typeable event
      , Show state
      , Eq state
@@ -244,7 +244,7 @@ effectHandler'
   -> (state -> Purview event m)
   -- ^ continuation
   -> Purview parentEvent m
-effectHandler' initEvents state reducer cont =
+effectHandler initEvents state reducer cont =
   EffectHandler Nothing Nothing initEvents state reducer cont
 
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -5,6 +5,7 @@
 module Component where
 
 import           Data.Typeable
+import           Data.Bifunctor
 
 import           Events
 
@@ -144,12 +145,41 @@ handler
   -- ^ Initial events to fire
   -> state
   -- ^ The initial state
-  -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))
+  -> (event -> state -> (state, [DirectedEvent parentEvent event]))
   -- ^ The reducer, or how the state should change for an event
   -> (state -> Purview event m)
   -- ^ The continuation / component to connect to
   -> Purview parentEvent m
 handler initEvents state reducer cont =
+  Handler Nothing Nothing initEvents state (constReducer reducer) cont
+  where constReducer reducer event state =
+          let (newState, events) = reducer event state
+          in (const newState, events)
+
+{-|
+
+The same as handler, except you have access to the state at
+application time.  Although rarely needed, if you have a long
+running pure calculation you may need to use this to avoid
+overwriting the state.
+
+-}
+handler'
+  :: ( Typeable event
+     , Show state
+     , Eq state
+     , Typeable state
+     )
+  => [DirectedEvent parentEvent event]
+  -- ^ Initial events to fire
+  -> state
+  -- ^ The initial state
+  -> (event -> state -> (state -> state, [DirectedEvent parentEvent event]))
+  -- ^ The reducer, or how the state should change for an event
+  -> (state -> Purview event m)
+  -- ^ The continuation / component to connect to
+  -> Purview parentEvent m
+handler' initEvents state reducer cont =
   Handler Nothing Nothing initEvents state reducer cont
 
 {-|
@@ -174,6 +204,36 @@ effectHandler
      , Show state
      , Eq state
      , Typeable state
+     , Functor m
+     )
+  => [DirectedEvent parentEvent event]
+  -- ^ Initial events to fire
+  -> state
+  -- ^ initial state
+  -> (event -> state -> m (state, [DirectedEvent parentEvent event]))
+  -- ^ reducer (note the m!)
+  -> (state -> Purview event m)
+  -- ^ continuation
+  -> Purview parentEvent m
+effectHandler initEvents state reducer cont =
+  EffectHandler Nothing Nothing initEvents state (constReducer reducer) cont
+  where constReducer reducer event state = fmap (Data.Bifunctor.first const) (reducer event state)
+
+{-|
+
+The same as the effectHandler, except you have access to the state at
+application time.  This allows you to prevent overwriting with old
+state.
+
+You'll want to use this if you're making a bunch of API requests to
+build up a list of results.
+
+-}
+effectHandler'
+  :: ( Typeable event
+     , Show state
+     , Eq state
+     , Typeable state
      )
   => [DirectedEvent parentEvent event]
   -- ^ Initial events to fire
@@ -184,8 +244,9 @@ effectHandler
   -> (state -> Purview event m)
   -- ^ continuation
   -> Purview parentEvent m
-effectHandler initEvents state reducer cont =
+effectHandler' initEvents state reducer cont =
   EffectHandler Nothing Nothing initEvents state reducer cont
+
 
 defaultHandler :: (() -> Purview () m) -> Purview () m
 defaultHandler =

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -40,8 +40,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = handler' [] "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
-          handler2 = handler' [] "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler1 = handler [] "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler2 = handler [] "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -53,8 +53,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler' [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler' [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -66,8 +66,8 @@ spec = parallel $ do
       it "continues going down the tree even if the state is the same at the top" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler' [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler' [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = snd . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
           newTree = snd . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -40,8 +40,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = handler [] "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
-          handler2 = handler [] "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler1 = handler' [] "initial state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
+          handler2 = handler' [] "different state" (\action state -> (const $ state <> action, [] :: [DefaultAction]))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -53,8 +53,8 @@ spec = parallel $ do
       it "diffs handler children if the state is different" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler' [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler' [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = div [ handler1 (const (text "the original")) ]
           newTree = div [ handler2 (const (text "this is different")) ]
 
@@ -66,8 +66,8 @@ spec = parallel $ do
       it "continues going down the tree even if the state is the same at the top" $ do
         let
           handler1 :: (String -> Purview String IO) -> Purview String IO
-          handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler1 = effectHandler' [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
+          handler2 = effectHandler' [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           oldTree = snd . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
           newTree = snd . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -62,14 +62,14 @@ spec = parallel $ do
         reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
-        clickHandler = handler [] 0 reducer
+        clickHandler = handler' [] 0 reducer
 
         (_, component) = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
 
         event = StateChangeEvent (\state -> state + 1 :: Int) (Just [])
 
         appliedClickHandler :: (Int -> Purview String IO) -> Purview () IO
-        appliedClickHandler = handler [] 1 reducer
+        appliedClickHandler = handler' [] 1 reducer
 
         (_, applied) = prepareTree $ appliedClickHandler $ \state -> div [ text (show state) ]
 
@@ -82,14 +82,14 @@ spec = parallel $ do
         reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview String IO
-        clickHandler = handler [] 0 reducer
+        clickHandler = handler' [] 0 reducer
 
         (_, component) = prepareTree $ clickHandler $ \_ -> clickHandler $ \_ -> div []
 
         event = StateChangeEvent (\state -> state + 1 :: Int) (Just [0])
 
         appliedClickHandler :: (Int -> Purview String IO) -> Purview String IO
-        appliedClickHandler = handler [] 1 reducer
+        appliedClickHandler = handler' [] 1 reducer
 
         (_, applied) = prepareTree $ clickHandler $ \_ -> appliedClickHandler $ \_ -> div []
 
@@ -104,7 +104,7 @@ spec = parallel $ do
         reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
-        clickHandler = handler [] (0 :: Int) reducer
+        clickHandler = handler' [] (0 :: Int) reducer
 
         (_, component) = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
 
@@ -124,13 +124,13 @@ spec = parallel $ do
         reducerA _      st = (0, [])
 
         clickHandlerA :: (Int -> Purview String IO) -> Purview () IO
-        clickHandlerA = handler [] (0 :: Int) reducerA
+        clickHandlerA = handler' [] (0 :: Int) reducerA
 
         reducerB "test" st = (5, [])
         reducerB _      st = (6, [])
 
         clickHandlerB :: (Int -> Purview String IO) -> Purview String IO
-        clickHandlerB = handler [] (0 :: Int) reducerB
+        clickHandlerB = handler' [] (0 :: Int) reducerB
 
         (_, component) = prepareTree $ clickHandlerA $ \_ -> clickHandlerB $ \_ -> div []
 
@@ -152,7 +152,7 @@ spec = parallel $ do
         reducer _      st = (const 0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
-        clickHandler = handler' [] (0 :: Int) reducer
+        clickHandler = handler [] (0 :: Int) reducer
 
         tree = clickHandler $ const $ div [ onClick "test" $ div [ text "up" ] ]
         (_, treeWithLocations) = prepareTree tree

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -58,8 +58,8 @@ spec = parallel $ do
   describe "applyNewState" $ do
     it "applies new state at the top level" $ do
       let
-        reducer "test" st = (const 1, [])
-        reducer _      st = (const 0, [])
+        reducer "test" st = (1, [])
+        reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
         clickHandler = handler [] 0 reducer
@@ -78,8 +78,8 @@ spec = parallel $ do
 
     it "applies new state at a lower level" $ do
       let
-        reducer "test" st = (const 1, [])
-        reducer _      st = (const 0, [])
+        reducer "test" st = (1, [])
+        reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview String IO
         clickHandler = handler [] 0 reducer
@@ -100,8 +100,8 @@ spec = parallel $ do
   describe "runEvent" $ do
     it "applies an event at the top level" $ do
       let
-        reducer "test" st = (const 1, [])
-        reducer _      st = (const 0, [])
+        reducer "test" st = (1, [])
+        reducer _      st = (0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
         clickHandler = handler [] (0 :: Int) reducer
@@ -120,14 +120,14 @@ spec = parallel $ do
 
     it "applies an event to the lower level" $ do
       let
-        reducerA "test" st = (const 1, [])
-        reducerA _      st = (const 0, [])
+        reducerA "test" st = (1, [])
+        reducerA _      st = (0, [])
 
         clickHandlerA :: (Int -> Purview String IO) -> Purview () IO
         clickHandlerA = handler [] (0 :: Int) reducerA
 
-        reducerB "test" st = (const 5, [])
-        reducerB _      st = (const 6, [])
+        reducerB "test" st = (5, [])
+        reducerB _      st = (6, [])
 
         clickHandlerB :: (Int -> Purview String IO) -> Purview String IO
         clickHandlerB = handler [] (0 :: Int) reducerB
@@ -152,7 +152,7 @@ spec = parallel $ do
         reducer _      st = (const 0, [])
 
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
-        clickHandler = handler [] (0 :: Int) reducer
+        clickHandler = handler' [] (0 :: Int) reducer
 
         tree = clickHandler $ const $ div [ onClick "test" $ div [ text "up" ] ]
         (_, treeWithLocations) = prepareTree tree

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -47,7 +47,7 @@ spec = parallel $ do
           handler' :: (String -> Purview String IO) -> Purview () IO
           handler' = handler [Self "up"] "" handle
 
-          handle "up" state = (state, [])
+          handle "up" state = (id, [])
 
           (initialActions, component) = prepareTree (handler' (const $ div []))
 
@@ -61,7 +61,7 @@ spec = parallel $ do
 
       it "works for effectHandler" $ do
         let
-          handler' = effectHandler [Self "up"] "" handle
+          handler' = effectHandler' [Self "up"] "" handle
 
           handle "up" state = pure (state, []) :: IO (String, [DirectedEvent () String])
 
@@ -77,8 +77,8 @@ spec = parallel $ do
 
       it "works for nested handlers" $ do
         let
-          parentHandler = handler [] "" handle
-          childHandler = handler [Self "to child", Parent "to parent"] "" handle
+          parentHandler = handler' [] "" handle
+          childHandler = handler' [Self "to child", Parent "to parent"] "" handle
 
           handle "" state = (state, [])
 
@@ -94,7 +94,7 @@ spec = parallel $ do
 
     it "assigns a location to handlers" $ do
       let
-        timeHandler = effectHandler' [] Nothing handle
+        timeHandler = effectHandler [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
@@ -114,7 +114,7 @@ spec = parallel $ do
 
     it "assigns a different location to child handlers" $ do
       let
-        timeHandler = effectHandler [] Nothing handle
+        timeHandler = effectHandler' [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
@@ -136,7 +136,7 @@ spec = parallel $ do
 
     it "assigns a different location to nested handlers" $ do
       let
-        timeHandler = effectHandler [] Nothing handle
+        timeHandler = effectHandler' [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -47,7 +47,7 @@ spec = parallel $ do
           handler' :: (String -> Purview String IO) -> Purview () IO
           handler' = handler [Self "up"] "" handle
 
-          handle "up" _ = (id, [])
+          handle "up" state = (state, [])
 
           (initialActions, component) = prepareTree (handler' (const $ div []))
 
@@ -63,7 +63,7 @@ spec = parallel $ do
         let
           handler' = effectHandler [Self "up"] "" handle
 
-          handle "up" _ = pure (id, []) :: IO (a -> a, [DirectedEvent () String])
+          handle "up" state = pure (state, []) :: IO (String, [DirectedEvent () String])
 
           (initialActions, component) = prepareTree (handler' (const $ div []))
 
@@ -80,7 +80,7 @@ spec = parallel $ do
           parentHandler = handler [] "" handle
           childHandler = handler [Self "to child", Parent "to parent"] "" handle
 
-          handle "" _ = (id, [])
+          handle "" state = (state, [])
 
           component :: Purview () IO
           component = parentHandler $ \_ -> childHandler $ \_ -> div []
@@ -94,13 +94,14 @@ spec = parallel $ do
 
     it "assigns a location to handlers" $ do
       let
-        timeHandler = effectHandler [] Nothing handle
+        timeHandler = effectHandler' [] Nothing handle
 
         handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
           time <- getCurrentTime
           pure (const $ Just time, [])
-        handle _         state = pure (const state, [])
+        handle _         state =
+          pure (const state, [])
 
         component = timeHandler (const (Text ""))
 
@@ -115,11 +116,12 @@ spec = parallel $ do
       let
         timeHandler = effectHandler [] Nothing handle
 
-        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
+        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
           time <- getCurrentTime
-          pure (const $ Just time, [])
-        handle _         state = pure (const state, [])
+          pure (Just time, [])
+        handle _         state =
+          pure (state, [])
 
         component = div
           [ timeHandler (const (Text ""))
@@ -136,11 +138,12 @@ spec = parallel $ do
       let
         timeHandler = effectHandler [] Nothing handle
 
-        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime -> Maybe UTCTime, [DirectedEvent String String])
+        handle :: String -> Maybe UTCTime -> IO (Maybe UTCTime, [DirectedEvent String String])
         handle "setTime" _     = do
           time <- getCurrentTime
-          pure (const $ Just time, [])
-        handle _         state = pure (const state, [])
+          pure (Just time, [])
+        handle _         state =
+          pure (state, [])
 
         component =
           timeHandler (const (timeHandler (const (Text ""))))

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -70,8 +70,9 @@ module Purview
   -- change state, or in the case of 'effectHandler', make API requests or call
   -- functions from your project.
   , handler
-  , defaultHandler
+  , handler'
   , effectHandler
+  , effectHandler'
 
   -- ** HTML helpers
   , div

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -14,9 +14,9 @@ downButton = onClick ("down" :: String) $ div [ text "down" ]
 reducer :: Applicative m => (Int -> Purview String m) -> Purview String m
 reducer = handler [] 0 action
   where
-    action :: String -> Int -> (Int -> Int, [DirectedEvent String String])
-    action "up" _ = (const 1, [])
-    action _    _ = (const 0, [])
+    action :: String -> Int -> (Int, [DirectedEvent String String])
+    action "up" _ = (1, [])
+    action _    _ = (0, [])
 
 -- counter :: Show a => a -> Purview parentAction action m
 counter state = div

--- a/src/PurviewSpec.hs
+++ b/src/PurviewSpec.hs
@@ -12,7 +12,7 @@ downButton :: Purview String m
 downButton = onClick ("down" :: String) $ div [ text "down" ]
 
 reducer :: Applicative m => (Int -> Purview String m) -> Purview String m
-reducer = handler [] 0 action
+reducer = handler' [] 0 action
   where
     action :: String -> Int -> (Int, [DirectedEvent String String])
     action "up" _ = (1, [])

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -20,8 +20,8 @@ nicely.
 testHandler :: (String -> Purview String IO) -> Purview String IO
 testHandler = effectHandler [] ("" :: String) reducer
   where
-    reducer :: String -> String -> IO (String -> String, [DirectedEvent String String])
-    reducer action state = pure (const "", [])
+    reducer :: String -> String -> IO (String, [DirectedEvent String String])
+    reducer action state = pure ("", [])
 
 sizedArbExpr :: Int -> Gen (Purview String IO)
 sizedArbExpr 0 = do pure $ text "always present"

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -18,7 +18,7 @@ nicely.
 -}
 
 testHandler :: (String -> Purview String IO) -> Purview String IO
-testHandler = effectHandler [] ("" :: String) reducer
+testHandler = effectHandler' [] ("" :: String) reducer
   where
     reducer :: String -> String -> IO (String, [DirectedEvent String String])
     reducer action state = pure ("", [])


### PR DESCRIPTION
This closes #88, for now at least.

As you can see now access to the state at application time is behind the handlers with `'` appended.  My reasoning is pretty straightforward, mostly that they'll be used less frequently than the simpler version.

This does introduce the possibility of confusing the user.  I imagine something like this could happen:
1. They're using a big `effectHandler` at the top of the page 
2. One of the actions is loading data 
3. They wonder why when the data finishes loading, other state is being overwritten 

Actually I may have just convinced myself this is a bad idea.