### PR TITLE
Add support for calling JS

### DIFF
--- a/src/EventHandling.hs
+++ b/src/EventHandling.hs
@@ -17,8 +17,9 @@ type Location = [Int]
 
 directedEventToInternalEvent :: (Typeable a, Typeable b) => Location -> Location -> DirectedEvent a b -> Event
 directedEventToInternalEvent parentLocation location directedEvent = case directedEvent of
-  Parent event -> InternalEvent { event=event, childId=Nothing, handlerId=Just parentLocation }
-  Self event   -> InternalEvent { event=event, childId=Nothing, handlerId=Just location }
+  Parent event       -> InternalEvent { event=event, childId=Nothing, handlerId=Just parentLocation }
+  Self event         -> InternalEvent { event=event, childId=Nothing, handlerId=Just location }
+  Browser name value -> JavascriptCallEvent name value
 
 {-|
 

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -61,6 +61,9 @@ data Event where
     :: ( Eq state, Show state, Typeable state )
     => (state -> state) -> Identifier -> Event
 
+  JavascriptCallEvent
+    :: String -> String -> Event
+
 instance Show Event where
   show (FromFrontendEvent event message location value) =
     show $ "{ event: "
@@ -110,3 +113,4 @@ or sent back in to the same handler.
 data DirectedEvent a b where
   Parent :: (Show a, Eq a) => a -> DirectedEvent a b
   Self :: (Show b, Eq b) => b -> DirectedEvent a b
+  Browser :: String -> String -> DirectedEvent a b

--- a/src/Events.hs
+++ b/src/Events.hs
@@ -84,6 +84,9 @@ instance Show Event where
     <> ", handlerId: " <> show handlerId
     <> " }"
 
+  show (JavascriptCallEvent name value) =
+    "{ event: \"callJS\" }"
+
 instance Eq Event where
   (FromFrontendEvent { childLocation=messageA, kind=eventA, location=locationA, value=valueA })
     == (FromFrontendEvent { childLocation=messageB, kind=eventB, location=locationB, value=valueB }) =
@@ -97,6 +100,8 @@ instance Eq Event where
       Just castEvent -> childId == childId' && handlerId == handlerId' && castEvent == event'
       Nothing        -> False
   (InternalEvent {}) == _ = False
+
+  (JavascriptCallEvent {}) == _ = False
 
 
 instance FromJSON Event where

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -171,9 +171,9 @@ This starts up the Warp server.  As a tiny example, to display some text saying 
 
 -}
 renderFullPage :: Typeable action => Configuration m -> Purview action m -> Builder
-renderFullPage Configuration { htmlHead, htmlEventHandlers, eventProducers } component =
+renderFullPage Configuration { htmlHead, htmlEventHandlers, eventProducers, eventListeners } component =
   fromString
-  $ wrapHtml htmlHead htmlEventHandlers eventProducers
+  $ wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners
   $ render
   $ snd
   $ prepareTree component

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -137,7 +137,6 @@ websocketScript = [r|
         bindLocationEnrichment();
         // bindLocations();
       } else if (event.event === "callJS") {
-        console.log("hello")
         const [fnToCall, withValue] = event.message;
         window[fnToCall](withValue);
       }

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -137,6 +137,7 @@ websocketScript = [r|
         bindLocationEnrichment();
         // bindLocations();
       } else if (event.event === "callJS") {
+        console.log("hello")
         const [fnToCall, withValue] = event.message;
         window[fnToCall](withValue);
       }

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -136,6 +136,9 @@ websocketScript = [r|
         bindEvents();
         bindLocationEnrichment();
         // bindLocations();
+      } else if (event.event === "callJS") {
+        const [fnToCall, withValue] = event.message;
+        window[fnToCall](withValue);
       }
     };
 
@@ -194,8 +197,8 @@ sendEventHelper = [r|
   }
 |]
 
-wrapHtml :: String -> [HtmlEventHandler] -> [String] -> String -> String
-wrapHtml htmlHead htmlEventHandlers eventProducers body =
+wrapHtml :: String -> [HtmlEventHandler] -> [String] -> [String] -> String -> String
+wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners body =
   "<!DOCTYPE html>"
   <> "<html>"
   <> "<head>"
@@ -206,6 +209,9 @@ wrapHtml htmlHead htmlEventHandlers eventProducers body =
   <> "</script>"
   <> "<script>"
   <> concatMap (<> "\n") eventProducers
+  <> "</script>"
+  <> "<script>"
+  <> concatMap (<> "\n") eventListeners
   <> "</script>"
   <> "</head>"
   <> "<body>"


### PR DESCRIPTION
Not too bad!  Now event handlers can produce messages that will call javascript functions.

```
component count = div
  [ class' "counter-display" $ div [ text (show count) ]
  , div [ onClick "increment" $ id' "increment" $ button [ text "increment" ] ]
  , id' "messages" $ div []
  ]

countHandler = handler' [] (0 :: Int) reducer
  where
    reducer "increment" state =
      let newState = state + 1
      in (newState, [Browser "addMessage" (show newState)])

render = countHandler component

jsMessageAdder = [r|
  const addMessage = (value) => {
    const messagesBlock = document.querySelector("#messages");
    messagesBlock.innerHTML = value;
  }
  window.addMessage = addMessage;
|]

getTest = (defaultConfiguration { eventListeners=[jsMessageAdder] }, render)
```