### PR TITLE
Add a quasiquoter for styling that puts CSS into the stylesheet

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ dependencies:
 - websockets                    >= 0.12.7 && < 0.13
 - blaze-builder                 >= 0.4.2 && < 0.5
 - http-types                    >= 0.12.3 && < 0.13
+- template-haskell
 
 # - hspec #
 # - QuickCheck #
@@ -67,6 +68,7 @@ library:
       - PurviewSpec
       - RenderingSpec
       - EventsSpec
+      - StyleSpec
       - Spec
 
 # executables:

--- a/package.yaml
+++ b/package.yaml
@@ -47,8 +47,8 @@ dependencies:
 - http-types                    >= 0.12.3 && < 0.13
 - template-haskell
 
-- hspec #
-- QuickCheck #
+# - hspec #
+# - QuickCheck #
 # - time #
 
 library:

--- a/package.yaml
+++ b/package.yaml
@@ -47,8 +47,8 @@ dependencies:
 - http-types                    >= 0.12.3 && < 0.13
 - template-haskell
 
-# - hspec #
-# - QuickCheck #
+- hspec #
+- QuickCheck #
 # - time #
 
 library:
@@ -69,6 +69,7 @@ library:
       - RenderingSpec
       - EventsSpec
       - StyleSpec
+      - CollectInitialSpec
       - Spec
 
 # executables:

--- a/purview.cabal
+++ b/purview.cabal
@@ -50,6 +50,7 @@ library
       Events
       PrepareTree
       Rendering
+      Style
       Wrapper
       Paths_purview
   hs-source-dirs:
@@ -63,6 +64,7 @@ library
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
+    , template-haskell
     , text >=1.2.4.1 && <1.3
     , websockets >=0.12.7 && <0.13
   default-language: Haskell2010
@@ -86,6 +88,8 @@ test-suite purview-test
       PurviewSpec
       Rendering
       RenderingSpec
+      Style
+      StyleSpec
       TreeGenerator
       Wrapper
       Paths_purview
@@ -105,6 +109,7 @@ test-suite purview-test
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
+    , template-haskell
     , text >=1.2.4.1 && <1.3
     , time >=1.9.3 && <1.12
     , websockets >=0.12.7 && <0.13
@@ -128,6 +133,7 @@ benchmark purview-perf-test
     , purview
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
+    , template-haskell
     , text >=1.2.4.1 && <1.3
     , websockets >=0.12.7 && <0.13
   buildable: False

--- a/purview.cabal
+++ b/purview.cabal
@@ -43,6 +43,9 @@ library
   exposed-modules:
       Purview
   other-modules:
+      CleanTree
+      CollectInitials
+      CollectInitialsSpec
       Component
       Diffing
       EventHandling
@@ -57,10 +60,12 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      aeson >=1.5.6 && <2.1
+      QuickCheck
+    , aeson >=1.5.6 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.0 && <0.12
+    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
@@ -73,6 +78,9 @@ test-suite purview-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      CleanTree
+      CollectInitials
+      CollectInitialsSpec
       Component
       ComponentSpec
       Diffing
@@ -124,11 +132,13 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      aeson >=1.5.6 && <2.1
+      QuickCheck
+    , aeson >=1.5.6 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.0 && <0.12
     , criterion >=1.5.13 && <1.6
+    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*

--- a/purview.cabal
+++ b/purview.cabal
@@ -45,7 +45,6 @@ library
   other-modules:
       CleanTree
       CollectInitials
-      CollectInitialsSpec
       Component
       Diffing
       EventHandling
@@ -78,7 +77,6 @@ test-suite purview-test
   other-modules:
       CleanTree
       CollectInitials
-      CollectInitialsSpec
       Component
       ComponentSpec
       Diffing

--- a/purview.cabal
+++ b/purview.cabal
@@ -60,12 +60,10 @@ library
       src
   ghc-options: -Wincomplete-patterns
   build-depends:
-      QuickCheck
-    , aeson >=1.5.6 && <2.1
+      aeson >=1.5.6 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.0 && <0.12
-    , hspec
     , http-types >=0.12.3 && <0.13
     , raw-strings-qq ==1.1.*
     , stm >=2.5.0 && <2.6
@@ -132,13 +130,11 @@ benchmark purview-perf-test
       performance
   ghc-options: -main-is Criterion
   build-depends:
-      QuickCheck
-    , aeson >=1.5.6 && <2.1
+      aeson >=1.5.6 && <2.1
     , base >=4.7 && <5
     , blaze-builder >=0.4.2 && <0.5
     , bytestring >=0.10.12.0 && <0.12
     , criterion >=1.5.13 && <1.6
-    , hspec
     , http-types >=0.12.3 && <0.13
     , purview
     , raw-strings-qq ==1.1.*

--- a/src/CleanTree.hs
+++ b/src/CleanTree.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE BangPatterns #-}
+-- |
+
+module CleanTree where
+
+import Data.Typeable
+import Data.List
+
+import Component
+
+import Debug.Trace
+
+removeClassCSS :: [(Hash, String)] -> Attributes e -> Attributes e
+removeClassCSS foundCSS attr = case attr of
+  Style (hash, css) ->
+    if hash /= "-1"
+    then case find (== (hash, css)) foundCSS of
+      Just _  -> Style (hash, "")
+      Nothing -> Style (hash, css)
+    else attr
+  _ -> attr
+
+cleanTree :: Typeable event => [(Hash, String)] -> Purview event m -> Purview event m
+cleanTree css component = case component of
+  Attribute attr cont ->
+    let
+      tree = cleanTree css cont
+      cleanedAttr = removeClassCSS css attr
+    in
+      Attribute cleanedAttr tree
+
+  Html kind children ->
+    let
+      cleanChildren = fmap (cleanTree css) children
+    in
+      Html kind cleanChildren
+
+  EffectHandler ploc loc initEvents state handler cont  ->
+    let
+      cleanCont = fmap (cleanTree css) cont
+    in
+      EffectHandler ploc loc [] state handler cleanCont
+
+  Handler ploc loc initEvents state handler cont ->
+    let
+      cleanCont = fmap (cleanTree css) cont
+    in
+      Handler ploc loc [] state handler cleanCont
+
+  r@Receiver {} -> r
+  t@(Text val)  -> t
+  v@(Value val) -> v

--- a/src/CollectInitials.hs
+++ b/src/CollectInitials.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+-- |
+
+module CollectInitials where
+
+import Data.Typeable
+
+import Component
+import Events
+
+import Debug.Trace
+
+type Location = [Int]
+
+getStyleFromAttr :: Attributes e -> Maybe (Hash, String)
+getStyleFromAttr attr = case attr of
+  Style (hash, css) ->
+    if hash /= "-1"
+    then trace ("CHECK2: " <> hash <> " " <> css) (Just (hash, css))  -- set the css to empty since it's been caught
+    else Nothing
+  _ -> Nothing
+
+directedEventToInternalEvent :: (Typeable a, Typeable b) => Location -> Location -> DirectedEvent a b -> Event
+directedEventToInternalEvent parentLocation location directedEvent = case directedEvent of
+  Parent event -> InternalEvent { event=event, childId=Nothing, handlerId=Just parentLocation }
+  Self event   -> InternalEvent { event=event, childId=Nothing, handlerId=Just location }
+  Browser {}   -> error "tried to turn a browser event into an internal event"
+
+collectInitials :: Typeable event => Purview event m -> ([Event], [(Hash, String)])
+collectInitials component = case component of
+  Attribute attr cont ->
+    let
+      (events, css) = collectInitials cont
+      possibleCss = getStyleFromAttr attr
+    in
+      case possibleCss of
+        Just newCss -> (events, newCss : css)
+        Nothing     -> (events, css)
+
+  Html kind children ->
+    let
+      eventsAndCss = fmap collectInitials children
+      events = concatMap fst eventsAndCss
+      css = concatMap snd eventsAndCss
+    in
+      (events, css)
+
+  EffectHandler ploc loc initEvents state _handler cont  ->
+    let
+      (events, css) = collectInitials (cont state)
+      internalizedEvents = case (ploc, loc) of
+        (Just ploc, Just loc) -> fmap (directedEventToInternalEvent ploc loc) initEvents
+        _                     -> error "EffectHandler missing locations"
+    in
+      (internalizedEvents <> events, css)
+
+  Handler ploc loc initEvents state _handler cont ->
+    let
+      (events, css) = collectInitials (cont state)
+      internalizedEvents = case (ploc, loc) of
+        (Just ploc, Just loc) -> fmap (directedEventToInternalEvent ploc loc) initEvents
+        _                     -> error "Handler missing locations"
+    in
+      (internalizedEvents <> events, css)
+
+  Receiver {} -> ([], [])
+  Text val    -> ([], [])
+  Value val   -> ([], [])

--- a/src/CollectInitials.hs
+++ b/src/CollectInitials.hs
@@ -15,8 +15,8 @@ type Location = [Int]
 getStyleFromAttr :: Attributes e -> Maybe (Hash, String)
 getStyleFromAttr attr = case attr of
   Style (hash, css) ->
-    if hash /= "-1"
-    then trace ("CHECK2: " <> hash <> " " <> css) (Just (hash, css))  -- set the css to empty since it's been caught
+    if hash /= "-1" && css /= ""
+    then Just (hash, css)  -- set the css to empty since it's been caught
     else Nothing
   _ -> Nothing
 

--- a/src/Component.hs
+++ b/src/Component.hs
@@ -9,6 +9,8 @@ import           Data.Bifunctor
 
 import           Events
 
+type Hash = String
+
 {-|
 
 Attributes are collected until an 'HTML' constructor is hit, where they
@@ -25,7 +27,7 @@ data Attributes event where
      -> (Maybe String -> event)  -- the string here is information from the browser
      -> Attributes event
         -- ^ part of creating handlers for different events, e.g. On "click"
-  Style :: String -> Attributes event
+  Style :: (Hash, String) -> Attributes event
         -- ^ inline css
   Generic :: String -> String -> Attributes event
         -- ^ for creating new Attributes to put on HTML, e.g. Generic "type" "radio" for type="radio".
@@ -322,14 +324,14 @@ text = Text
 
 {-|
 
-For adding styles
+For adding inline styles.  Good for dynamic parts of styling.
 
 > blue = style "color: \"blue\";"
 > blueButton = blue $ button [ text "I'm blue" ]
 
 -}
-style :: String -> Purview event m -> Purview event m
-style = Attribute . Style
+istyle :: String -> Purview event m -> Purview event m
+istyle str = Attribute $ Style ("-1", str)
 
 {-|
 

--- a/src/DiffingSpec.hs
+++ b/src/DiffingSpec.hs
@@ -68,8 +68,8 @@ spec = parallel $ do
           handler1 :: (String -> Purview String IO) -> Purview String IO
           handler1 = effectHandler [] "initial state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
           handler2 = effectHandler [] "different state" (\action state -> pure $ (const $ state <> action, ([] :: [DirectedEvent String String])))
-          oldTree = snd . prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
-          newTree = snd . prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
+          oldTree = prepareTree $ div [ handler1 . const $ handler1 (const (text "the original")) ]
+          newTree = prepareTree $ div [ handler1 . const $ handler2 (const (text "this is different")) ]
 
         diff (Just [0, 0]) [] oldTree newTree `shouldBe`
           [ Update [0, 0] (EffectHandler

--- a/src/EventHandlingSpec.hs
+++ b/src/EventHandlingSpec.hs
@@ -64,14 +64,14 @@ spec = parallel $ do
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
         clickHandler = handler' [] 0 reducer
 
-        (_, component) = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
+        component = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
 
         event = StateChangeEvent (\state -> state + 1 :: Int) (Just [])
 
         appliedClickHandler :: (Int -> Purview String IO) -> Purview () IO
         appliedClickHandler = handler' [] 1 reducer
 
-        (_, applied) = prepareTree $ appliedClickHandler $ \state -> div [ text (show state) ]
+        applied = prepareTree $ appliedClickHandler $ \state -> div [ text (show state) ]
 
       -- state should now be 1
       applyNewState event component `shouldBe` applied
@@ -84,14 +84,14 @@ spec = parallel $ do
         clickHandler :: (Int -> Purview String IO) -> Purview String IO
         clickHandler = handler' [] 0 reducer
 
-        (_, component) = prepareTree $ clickHandler $ \_ -> clickHandler $ \_ -> div []
+        component = prepareTree $ clickHandler $ \_ -> clickHandler $ \_ -> div []
 
         event = StateChangeEvent (\state -> state + 1 :: Int) (Just [0])
 
         appliedClickHandler :: (Int -> Purview String IO) -> Purview String IO
         appliedClickHandler = handler' [] 1 reducer
 
-        (_, applied) = prepareTree $ clickHandler $ \_ -> appliedClickHandler $ \_ -> div []
+        applied = prepareTree $ clickHandler $ \_ -> appliedClickHandler $ \_ -> div []
 
       -- state should now be 1
       applyNewState event component `shouldBe` applied
@@ -106,7 +106,7 @@ spec = parallel $ do
         clickHandler :: (Int -> Purview String IO) -> Purview () IO
         clickHandler = handler' [] (0 :: Int) reducer
 
-        (_, component) = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
+        component = prepareTree $ clickHandler $ \state -> div [ text (show state) ]
 
         event = InternalEvent { event = "test" :: String, childId = Nothing, handlerId = Just [] }
 
@@ -132,7 +132,7 @@ spec = parallel $ do
         clickHandlerB :: (Int -> Purview String IO) -> Purview String IO
         clickHandlerB = handler' [] (0 :: Int) reducerB
 
-        (_, component) = prepareTree $ clickHandlerA $ \_ -> clickHandlerB $ \_ -> div []
+        component = prepareTree $ clickHandlerA $ \_ -> clickHandlerB $ \_ -> div []
 
         event = InternalEvent { event = "test" :: String, childId = Nothing, handlerId = Just [0] }
 
@@ -155,7 +155,7 @@ spec = parallel $ do
         clickHandler = handler [] (0 :: Int) reducer
 
         tree = clickHandler $ const $ div [ onClick "test" $ div [ text "up" ] ]
-        (_, treeWithLocations) = prepareTree tree
+        treeWithLocations = prepareTree tree
 
         -- EffectHandler Just [] Just [] "0" div [  Attr On "click" Just [0,0] div [  "up" ]  ]
         event' = FromFrontendEvent { kind="click", childLocation=Just [0, 0], location=Just [] }

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -78,7 +78,7 @@ eventLoop' message devMode runner log eventBus connection component = do
 
   when devMode $ log $ "sending> " <> show renderedDiffs
 
-  WebSockets.sendTextData
+  unless (null css) $ WebSockets.sendTextData
     connection
     (encode $ ForFrontEndEvent { event = "setCSS", message = css })
 

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -50,6 +50,10 @@ eventLoop' message devMode runner log eventBus connection component = do
     (initialEvents, css) = collectInitials locatedTree
     -- 3. removes captured css and initial events
     newTree' = cleanTree css locatedTree
+    -- why pass in the found css?  otherwise haskell will optimize by
+    -- putting the function that removes css into the tree, which results
+    -- in the css being removed before it's been found by collectInitials.
+    -- or at least, that's what seemed to be happening.  very funny.
 
     event = findEvent message newTree'
 

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -39,7 +39,7 @@ eventLoop' message devMode runner log eventBus connection component = do
     -- this collects any actions that should run once
     -- while assigning locations / identifiers
     -- to the event handlers
-    (initialEvents, newTree) = prepareTree component
+    (initialEvents, css, newTree) = prepareTree component
     event = findEvent message newTree
 
   mapM_ (atomically . writeTChan eventBus) initialEvents

--- a/src/EventLoop.hs
+++ b/src/EventLoop.hs
@@ -36,8 +36,8 @@ eventLoop'
   -> IO (Maybe (Purview event m))
 eventLoop' message devMode runner log eventBus connection component = do
   let
-    -- this collects any actions that should run once and sets them
-    -- to "run" in the tree, while assigning locations / identifiers
+    -- this collects any actions that should run once
+    -- while assigning locations / identifiers
     -- to the event handlers
     (initialEvents, newTree) = prepareTree component
     event = findEvent message newTree

--- a/src/PrepareTree.hs
+++ b/src/PrepareTree.hs
@@ -54,7 +54,7 @@ prepareTree' parentLocation location component = case component of
       (possibleCss, newAttr) = getStyleFromAttr $ addLocationToAttr location attr
     in
       case possibleCss of
-        Just newCss -> (events, newCss : css, Attribute (addLocationToAttr location attr) child)
+        Just newCss -> (events, newCss : css, Attribute newAttr child)
         Nothing     -> (events, css, Attribute newAttr child)
 
   Html kind children ->

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -156,10 +156,12 @@ spec = parallel $ do
       show graphWithLocation `shouldBe` "EffectHandler Just [] Just [] Nothing EffectHandler Just [] Just [0] Nothing \"\""
 
     it "picks up css" $ do
-      let component = (Attribute $ Style ("123", "color: blue;")) $ div []
-          (_, css, _) = prepareTree component :: ([Event], [(Hash, String)], Purview () m)
+      let
+        component = (Attribute $ Style ("123", "color: blue;")) $ div []
+        (_, css, preparedTree) = prepareTree component :: ([Event], [(Hash, String)], Purview () m)
 
       css `shouldBe` [("123", "color: blue;")]
+      show preparedTree `shouldBe` "Attr Style (\"123\",\"\") div [  ] "
 
 
 

--- a/src/PrepareTreeSpec.hs
+++ b/src/PrepareTreeSpec.hs
@@ -10,6 +10,7 @@ import TreeGenerator ()
 import Events
 import Component
 import PrepareTree
+import PrepareTree (prepareTree)
 
 type UTCTime = Integer
 
@@ -153,6 +154,13 @@ spec = parallel $ do
         (_, _, graphWithLocation) = prepareTree component
 
       show graphWithLocation `shouldBe` "EffectHandler Just [] Just [] Nothing EffectHandler Just [] Just [0] Nothing \"\""
+
+    it "picks up css" $ do
+      let component = (Attribute $ Style ("123", "color: blue;")) $ div []
+          (_, css, _) = prepareTree component :: ([Event], [(Hash, String)], Purview () m)
+
+      css `shouldBe` [("123", "color: blue;")]
+
 
 
 main :: IO ()

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -75,6 +75,9 @@ module Purview
   , effectHandler'
   , receiver
 
+  -- ** QuasiQuoter for styling
+  , style
+
   -- ** HTML helpers
   , div
   , span
@@ -119,6 +122,7 @@ import           Control.Concurrent.STM.TChan
 import           Control.Monad.STM
 import           Control.Concurrent
 
+import           Style (style)
 import           Component
 import           EventLoop
 import           Events

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -172,11 +172,11 @@ This starts up the Warp server.  As a tiny example, to display some text saying 
 -}
 renderFullPage :: Typeable action => Configuration m -> Purview action m -> Builder
 renderFullPage Configuration { htmlHead, htmlEventHandlers, eventProducers, eventListeners } component =
-  fromString
-  $ wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners
-  $ render
-  $ snd
-  $ prepareTree component
+  let
+    rendered = render . snd $ prepareTree component
+    wrap = wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners
+  in
+    fromString $ wrap rendered
 
 startWebSocketLoop
   :: (Monad m, Typeable action)

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -129,6 +129,8 @@ import           Events
 import           PrepareTree
 import           Rendering
 import           Wrapper
+import           CollectInitials
+import           CleanTree
 
 type Log m = String -> m ()
 
@@ -177,8 +179,9 @@ This starts up the Warp server.  As a tiny example, to display some text saying 
 renderFullPage :: Typeable action => Configuration m -> Purview action m -> Builder
 renderFullPage Configuration { htmlHead, htmlEventHandlers, eventProducers, eventListeners } component =
   let
-    (initialEvents, css, preparedComponent) = prepareTree component
-    rendered = render preparedComponent
+    locatedComponent = prepareTree component
+    (initialEvents, css) = collectInitials locatedComponent
+    rendered = render (cleanTree css locatedComponent)
     wrap = wrapHtml css htmlHead htmlEventHandlers eventProducers eventListeners
   in
     fromString $ wrap rendered

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -173,8 +173,9 @@ This starts up the Warp server.  As a tiny example, to display some text saying 
 renderFullPage :: Typeable action => Configuration m -> Purview action m -> Builder
 renderFullPage Configuration { htmlHead, htmlEventHandlers, eventProducers, eventListeners } component =
   let
-    rendered = render . snd $ prepareTree component
-    wrap = wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners
+    (initialEvents, css, preparedComponent) = prepareTree component
+    rendered = render preparedComponent
+    wrap = wrapHtml css htmlHead htmlEventHandlers eventProducers eventListeners
   in
     fromString $ wrap rendered
 

--- a/src/Purview.hs
+++ b/src/Purview.hs
@@ -87,7 +87,7 @@ module Purview
   , button
   , form
   , input
-  , style
+  , istyle
   , id'
   , class'
 

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -16,7 +16,7 @@ isGeneric (Generic _ _) = True
 isGeneric _             = False
 
 getStyle :: Attributes a -> String
-getStyle (Style style') = style'
+getStyle (Style (hash, style')) = style'
 getStyle _              = ""
 
 renderGeneric :: Attributes a -> String

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -16,8 +16,10 @@ isGeneric (Generic _ _) = True
 isGeneric _             = False
 
 getStyle :: Attributes a -> String
-getStyle (Style (hash, style')) = style'
-getStyle _              = ""
+getStyle (Style (hash, style')) =
+  -- inline styles are just given a hash of -1
+  if hash == "-1" then style' else ""
+getStyle _ = ""
 
 renderGeneric :: Attributes a -> String
 renderGeneric attr = case attr of
@@ -61,6 +63,7 @@ render' attrs tree = case tree of
   Text val -> val
 
   Attribute attr rest ->
+    -- collecting all the attributes till we hit html
     render' (attr:attrs) rest
 
   EffectHandler parentLocation location initEvents state _ cont ->

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -15,11 +15,20 @@ isGeneric :: Attributes a -> Bool
 isGeneric (Generic _ _) = True
 isGeneric _             = False
 
+isClass :: Attributes a -> Bool
+isClass (Generic "class" _) = True
+isClass _                   = False
+
 getStyle :: Attributes a -> String
 getStyle (Style (hash, style')) =
   -- inline styles are just given a hash of -1
   if hash == "-1" then style' else ""
 getStyle _ = ""
+
+getClassBasedStyle :: Attributes a -> String
+getClassBasedStyle (Style (hash, style')) =
+  if style' == "" then hash else ""
+getClassBasedStyle _ = ""
 
 renderGeneric :: Attributes a -> String
 renderGeneric attr = case attr of
@@ -32,16 +41,25 @@ renderAttributes attrs =
     styles = concatMap getStyle attrs
     renderedStyle = if not (null styles) then " style=" <> show styles else ""
 
+    classStyles = filter (not . null) $ fmap getClassBasedStyle attrs
+    existingClasses = (\(Generic _ name) -> name) <$> filter isClass attrs
+    combinedClasses = classStyles <> existingClasses
+
+    renderedClasses =
+      if not (null combinedClasses)
+      then " class=\"" <> concatMap (\class' -> class') combinedClasses <> "\""
+      else ""
+
     listeners = filter isOn attrs
     renderedListeners = concatMap
       (\(On name ident action) -> " " <> name <> "-location=" <> unpack (encode ident))
       listeners
     noticeToBind = if null listeners then "" else " bubbling-bound"
 
-    generics = filter isGeneric attrs
+    generics = filter (not . isClass) $ filter isGeneric attrs
     renderedGenerics = concatMap renderGeneric generics
   in
-    renderedStyle <> noticeToBind <> renderedListeners <> renderedGenerics
+    renderedStyle <> noticeToBind <> renderedListeners <> renderedGenerics <> renderedClasses
 
 {-|
 

--- a/src/Rendering.hs
+++ b/src/Rendering.hs
@@ -41,6 +41,7 @@ renderAttributes attrs =
     styles = concatMap getStyle attrs
     renderedStyle = if not (null styles) then " style=" <> show styles else ""
 
+    -- TODO: this is uggo
     classStyles = filter (not . null) $ fmap getClassBasedStyle attrs
     existingClasses = (\(Generic _ name) -> name) <$> filter isClass attrs
     combinedClasses = classStyles <> existingClasses

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -109,6 +109,12 @@ spec = parallel $ do
         `shouldBe`
         "<div handler=\"[0,1]\" parent-handler=\"[]\" receiver-name=\"test\"></div>"
 
+    it "can render a class based style" $ do
+      let component = (Attribute $ Style ("123", "")) $ div []
+
+      render component
+        `shouldBe`
+        "<div class=\"123\"></div>"
 
 main :: IO ()
 main = hspec spec

--- a/src/RenderingSpec.hs
+++ b/src/RenderingSpec.hs
@@ -88,15 +88,15 @@ spec = parallel $ do
 
 
     it "can render a style" $ do
-      let element = style "color: blue;" $ div [ text "blue" ]
+      let element = istyle "color: blue;" $ div [ text "blue" ]
 
       render element
         `shouldBe`
         "<div style=\"color: blue;\">blue</div>"
 
     it "can render composed styles" $ do
-      let blue = style "color: blue;"
-          halfSize = style "width: 50%; height: 50%;"
+      let blue = istyle "color: blue;"
+          halfSize = istyle "width: 50%; height: 50%;"
 
       render (blue . halfSize $ div [ text "box" ])
         `shouldBe`

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -26,7 +26,8 @@ style = QuasiQuoter
 
 style' :: String -> Q Exp
 style' css =
-  let hashed = show $ hash css
+  -- pretty funny, css needs a leading character (not number)
+  let hashed = 'p' : show (hash css)
   in [| Attribute (Style (hashed, css)) |]
 
 

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -12,17 +12,9 @@ import Language.Haskell.TH.Quote
 import Data.Bits
 import Data.List
 
-import Component (Attributes)
+import Component (Attributes ( Style ), Purview ( Attribute ))
 
 -- thanks https://stackoverflow.com/questions/59399050/haskell-making-quasi-quoted-values-strict-evaluated-at-compile-time
-
--- newtype Style = Style (String, String)
---   deriving (Show, Eq)
-
-style' :: String -> Q Exp
-style' css =
-  let hashed = show $ hash css
-  in [| Style (hashed, css) |]
 
 style :: QuasiQuoter
 style = QuasiQuoter
@@ -31,6 +23,12 @@ style = QuasiQuoter
   , quotePat = error "quotePat not implemented"
   , quoteExp = style'
   }
+
+style' :: String -> Q Exp
+style' css =
+  let hashed = show $ hash css
+  in [| Attribute (Style (hashed, css)) |]
+
 
 -- snagged from https://stackoverflow.com/a/9263004/1361890
 hash :: String -> Int

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE TemplateHaskell, DeriveLift, QuasiQuotes #-}
+
+-- |
+module Style
+  ( style
+  , Style (..)
+  )
+where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Quote
+
+import Data.Bits
+import Data.List
+
+-- thanks https://stackoverflow.com/questions/59399050/haskell-making-quasi-quoted-values-strict-evaluated-at-compile-time
+
+newtype Style = Style (String, String)
+  deriving (Show, Eq)
+
+style' :: String -> Q Exp
+style' css =
+  let hashed = show $ hash css
+  in [| Style (hashed, css) |]
+
+style :: QuasiQuoter
+style = QuasiQuoter
+  { quoteDec = error "quoteDec not implemented"
+  , quoteType = error "quoteType not implemented"
+  , quotePat = error "quotePat not implemented"
+  , quoteExp = style'
+  }
+
+-- snagged from https://stackoverflow.com/a/9263004/1361890
+hash :: String -> Int
+hash = foldl' (\h c -> 33 * h `xor` fromEnum c) 5381

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -3,7 +3,6 @@
 -- |
 module Style
   ( style
-  , Style (..)
   )
 where
 
@@ -13,10 +12,12 @@ import Language.Haskell.TH.Quote
 import Data.Bits
 import Data.List
 
+import Component (Attributes)
+
 -- thanks https://stackoverflow.com/questions/59399050/haskell-making-quasi-quoted-values-strict-evaluated-at-compile-time
 
-newtype Style = Style (String, String)
-  deriving (Show, Eq)
+-- newtype Style = Style (String, String)
+--   deriving (Show, Eq)
 
 style' :: String -> Q Exp
 style' css =

--- a/src/Style.hs
+++ b/src/Style.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE TemplateHaskell, DeriveLift, QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 -- |
 module Style

--- a/src/StyleSpec.hs
+++ b/src/StyleSpec.hs
@@ -18,7 +18,7 @@ spec = parallel $ do
     it "produces a non-empty style" $ do
       let styled = [style|blue;|] component
 
-      show styled `shouldBe` "Attr Style (\"210629223392\",\"blue;\") div [  ] "
+      show styled `shouldBe` "Attr Style (\"p210629223392\",\"blue;\") div [  ] "
 
     it "produces the same hash for the same style" $ do
       let

--- a/src/StyleSpec.hs
+++ b/src/StyleSpec.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+-- |
+
+module StyleSpec where
+
+import Test.Hspec
+
+import Style (Style (..), style)
+
+spec :: SpecWith ()
+spec = parallel $ do
+  describe "the style quasiquoter" $ do
+    it "produces a non-empty style" $ do
+      let Style (hash, style') = [style|blue;|]
+
+      hash `shouldSatisfy` (not . null)
+      style' `shouldBe` "blue;"
+
+    it "produces the same hash for the same style" $ do
+      let
+        styleA = [style|blue;|]
+        styleB = [style|blue;|]
+
+      styleA `shouldBe` styleB
+
+    it "produces different hashes for different styles" $ do
+      let
+        Style (hashA, _) = [style|blue;|]
+        Style (hashB, _) = [style|red;|]
+
+      hashA `shouldNotBe` hashB

--- a/src/StyleSpec.hs
+++ b/src/StyleSpec.hs
@@ -4,30 +4,35 @@
 
 module StyleSpec where
 
+import Prelude hiding (div)
 import Test.Hspec
 
-import Component (Attributes (Style))
+import Component
 import Style (style)
 
 spec :: SpecWith ()
 spec = parallel $ do
   describe "the style quasiquoter" $ do
-    it "produces a non-empty style" $ do
-      let Style (hash, style') = [style|blue;|]
+    let component = div []
 
-      hash `shouldSatisfy` (not . null)
-      style' `shouldBe` "blue;"
+    it "produces a non-empty style" $ do
+      let styled = [style|blue;|] component
+
+      show styled `shouldBe` "Attr Style (\"210629223392\",\"blue;\") div [  ] "
 
     it "produces the same hash for the same style" $ do
       let
-        styleA = [style|blue;|]
-        styleB = [style|blue;|]
+        styleA = [style|blue;|] component
+        styleB = [style|blue;|] component
 
       styleA `shouldBe` styleB
 
     it "produces different hashes for different styles" $ do
       let
-        Style (hashA, _) = [style|blue;|]
-        Style (hashB, _) = [style|red;|]
+        styleA = [style|blue;|] component
+        styleB = [style|red;|] component
 
-      hashA `shouldNotBe` hashB
+      styleA `shouldNotBe` styleB
+
+main :: IO ()
+main = hspec spec

--- a/src/StyleSpec.hs
+++ b/src/StyleSpec.hs
@@ -6,7 +6,8 @@ module StyleSpec where
 
 import Test.Hspec
 
-import Style (Style (..), style)
+import Component (Attributes (Style))
+import Style (style)
 
 spec :: SpecWith ()
 spec = parallel $ do

--- a/src/TreeGenerator.hs
+++ b/src/TreeGenerator.hs
@@ -29,7 +29,7 @@ sizedArbExpr n = do
   es <- vectorOf 2 (sizedArbExpr (n-1))
   elements
     [ div es
-    , style "" $ div es
+    , istyle "" $ div es
     , testHandler (const $ div es)
     ]
 

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -197,8 +197,11 @@ sendEventHelper = [r|
   }
 |]
 
-wrapHtml :: String -> [HtmlEventHandler] -> [String] -> [String] -> String -> String
-wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners body =
+prepareCss :: [(String, String)] -> String
+prepareCss = concatMap (\(hash, css) -> "." <> hash <> " {" <> css <> "}")
+
+wrapHtml :: [(String, String)] -> String -> [HtmlEventHandler] -> [String] -> [String] -> String -> String
+wrapHtml css htmlHead htmlEventHandlers eventProducers eventListeners body =
   "<!DOCTYPE html>"
   <> "<html>"
   <> "<head>"
@@ -213,6 +216,9 @@ wrapHtml htmlHead htmlEventHandlers eventProducers eventListeners body =
   <> "<script>"
   <> concatMap (<> "\n") eventListeners
   <> "</script>"
+  <> "<style>"
+  <> prepareCss css
+  <> "</style>"
   <> "</head>"
   <> "<body>"
   <> body

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -139,6 +139,13 @@ websocketScript = [r|
       } else if (event.event === "callJS") {
         const [fnToCall, withValue] = event.message;
         window[fnToCall](withValue);
+      } else if (event.event === "setCSS") {
+        console.log(event.message);
+        var sheet = window.document.styleSheets[0];
+        event.message.map(cssRule => {
+            const [name, css] = cssRule;
+            sheet.insertRule('.' + name + '{ ' + css + ' }', sheet.cssRules.length);
+        })
       }
     };
 

--- a/src/Wrapper.hs
+++ b/src/Wrapper.hs
@@ -198,7 +198,7 @@ sendEventHelper = [r|
 |]
 
 prepareCss :: [(String, String)] -> String
-prepareCss = concatMap (\(hash, css) -> "." <> hash <> " {" <> css <> "}")
+prepareCss = concatMap (\(hash, css) -> "." <> hash <> " {" <> css <> "}\n")
 
 wrapHtml :: [(String, String)] -> String -> [HtmlEventHandler] -> [String] -> [String] -> String -> String
 wrapHtml css htmlHead htmlEventHandlers eventProducers eventListeners body =


### PR DESCRIPTION
Hahahaaa YES it works!!

This moves styling into a CSS stylesheet and assigns hashes as classes to components, as it should be.  It even includes a quasiquoter so you can do something _very_ nice (taken from the e2e tests):

```haskell
{-# LANGUAGE QuasiQuotes #-}

module Cases.ClassBasedCSS where

import Prelude hiding (div)

import Purview hiding (render)

fancyStyle = [style|
  height: 20px;
  width: 20px;
  color: green;
|]

simpleStyle = [style|
  height: 20px;
  width: 20px;
  color: red;
|]

component count = div
  [ class' "counter-display" $ div [ text (show count) ]
  , div [ onClick "increment" $ id' "increment" $ button [ text "increment" ]
        , onClick "decrement" $ id' "decrement" $ button [ text "decrement" ]
        ]
  , case count of
      1 -> fancyStyle $ div [ text "should have a new style" ]
      _ -> simpleStyle $ div [ text "the default style" ]
  ]

countHandler = handler' [] (0 :: Int) reducer
  where
    reducer "increment" state = (state + 1, [])
    reducer "decrement" state = (state - 1, [])

render = countHandler component

getTest = (defaultConfiguration, render)

```
I wrote some terrible code as a part of this, wrestling with some laziness, but it's a good first step for refactoring the event loop which has gotten pretty messy.  With this and the Javascript communication, I can finally say this library meets my functionality requirements and it's only going to get better from here.

closes #115 YEAHHH